### PR TITLE
show compile icon only when the current language is overpy

### DIFF
--- a/VS Code Extension/package.json
+++ b/VS Code Extension/package.json
@@ -60,6 +60,7 @@
         "menus": {
             "editor/title": [
                 {
+                    "when": "resourceLangId == overpy",
                     "command": "extension.compile",
                     "group": "navigation@6"
                 }


### PR DESCRIPTION
Hides the compile icon if the user is not on an .opy file