### PR TITLE
fix unknown min max operators

### DIFF
--- a/src/compiler/parser.js
+++ b/src/compiler/parser.js
@@ -563,12 +563,12 @@ function parse(content, kwargs={}) {
                 "max=": "max",
             };
 
-            var variable = parse(operands[0]);
+            const variable = parse(operands[0]);
             const opName = opToFuncMapping[operator];
             const value = parse(operands[1]);
 
             //Do not de-optimize if the variable is random. Else we get random.choice(A) += 1 transformed to random.choice(A) = random.choice(A) + 1.
-            if (areAstsEqual(variable, variable)) {
+            if (areAstsEqual(variable, value)) {
                 return new Ast("__modifyVar__", [
                     variable,
                     new Ast(opName, [], [], "__Operation__"),

--- a/src/tests/results/comments.txt
+++ b/src/tests/results/comments.txt
@@ -20,7 +20,7 @@ rule ("comments") {
         Modify Global Variable(C, Add, True);
         "D++"
         Modify Global Variable(D, Add, True);
-        "nothing\nsome array"
+        "nothing\r\nsome array"
         Set Global Variable(A, Array(1, 2, 3));
     }
 }


### PR DESCRIPTION
This PR fixes a bug introduced in b1055e9a4946b0c9019c0f9b3d2f90f3bb70741a which always prevented de-optimization of operators such as `+=`. This also had the unintended side-effect of completely preventing the `max=` and `min=` operators from being recognized.
