### PR TITLE
fix(js macros): do not overwrite global `console` in local scope

### DIFF
--- a/src/jsInterpreter.ts
+++ b/src/jsInterpreter.ts
@@ -3,15 +3,15 @@ import Interpreter from "js-interpreter";
 
 // Add some basic functions to the interpreter
 const initFunc = function (interpreter: any, globalObject: any) {
-  const console = interpreter.nativeToPseudo({});
-  interpreter.setProperty(globalObject, "console", console);
+  const macroConsoleObject = interpreter.nativeToPseudo({});
+  interpreter.setProperty(globalObject, "console", macroConsoleObject);
 
   const consoleLogWrapper = function (text: string) {
     console.log(text);
   };
 
   interpreter.setProperty(
-    console,
+    macroConsoleObject,
     "log",
     interpreter.createNativeFunction(consoleLogWrapper),
   );


### PR DESCRIPTION
Fixes `console.log` in js macros throwing an error due to `console2` (or `x` in production builds) being undefined.