### PR TITLE
fix: prevent state from previous compile from being retained

### DIFF
--- a/src/compiler/compiler.ts
+++ b/src/compiler/compiler.ts
@@ -72,6 +72,7 @@ import {
   Variable,
 } from "../types";
 import { compileCustomGameSettingsDict } from "../utils/compilation";
+import { reinitInterpreter } from "../jsInterpreter";
 
 /**
  * @returns An object containing the compiled result along with associated metadata
@@ -98,6 +99,7 @@ export async function compile(
 
   if (DEBUG_PROFILER) console.profile();
   resetGlobalVariables(language);
+  reinitInterpreter("");
   // rootPath = _rootPath;
   setRootPath(_rootPath);
 

--- a/src/jsInterpreter.ts
+++ b/src/jsInterpreter.ts
@@ -16,4 +16,7 @@ const initFunc = function (interpreter: any, globalObject: any) {
     interpreter.createNativeFunction(consoleLogWrapper),
   );
 };
-export const JSInterpreter = new Interpreter("", initFunc);
+export let JSInterpreter = new Interpreter("", initFunc);
+export const reinitInterpreter = (code: string) => {
+  JSInterpreter = new Interpreter(code, initFunc);
+};


### PR DESCRIPTION
The JS interpreter previously retained the code state from previous
compilations, which could result in unexpected behavior in some circumstances.
