### PR TITLE
fix: custom game settings parsing and missing Roadhog setting

### DIFF
--- a/.github/workflows/behavior_test.yml
+++ b/.github/workflows/behavior_test.yml
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: npm
-      - uses: actions/cache/restore@v3
+      - uses: actions/cache/restore@v4
         with:
           key: ${{ github.run_id }}-node-modules
           path: |

--- a/.github/workflows/behavior_test.yml
+++ b/.github/workflows/behavior_test.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 22.4
           cache: npm
       - uses: actions/cache/restore@v4
         with:

--- a/package.json
+++ b/package.json
@@ -201,7 +201,7 @@
     "watch-tests": "tsc -p . -w --outDir out",
     "pretest": "npm run compile-standalone",
     "check-types": "tsc --noEmit",
-    "lint": "eslint src --ext ts",
+    "lint": "npx eslint src --ext ts",
     "test": "node runTests.mjs",
     "prepare": "husky"
   },

--- a/src/data/customGameSettings.ts
+++ b/src/data/customGameSettings.ts
@@ -4304,6 +4304,7 @@ export const customGameSettingsSchema: CustomGameSettingSchema =
                         "orisa",
                         "pharah",
                         "reinhardt",
+                        "roadhog",
                         "sigma",
                         "soldier",
                         "sombra",

--- a/src/tests/decompiler/customGameSettings.txt
+++ b/src/tests/decompiler/customGameSettings.txt
@@ -46,6 +46,12 @@ settings
             {
                 Hover Jets Maximum Time: 300%
             }
+
+            Roadhog
+            {
+                Take a Breather Cooldown Time: 0%
+                Whole Hog Knockback Scalar: 200%
+            }
         }
     }
 }

--- a/src/tests/decompiler/results/customGameSettings.opy
+++ b/src/tests/decompiler/results/customGameSettings.opy
@@ -28,6 +28,10 @@ settings {
             "pharah": {
                 "passiveMaxTime%": 300
             },
+            "roadhog": {
+                "secondaryFireCooldown%": 0,
+                "ultKb%": 200
+            },
             "general": {
                 "abilityCooldown%": 137
             }

--- a/src/utils/decompilation.ts
+++ b/src/utils/decompilation.ts
@@ -106,19 +106,18 @@ export function decompileCustomGameSettingsDict(
     for (var key of objKeys) {
       if (currentLanguage in kwObj[key]) {
         if (
-          elem
-            .toLowerCase()
-            .startsWith(kwObj[key][currentLanguage].toLowerCase())
+          potentialKey.toLowerCase() ===
+          kwObj[key][currentLanguage].toLowerCase()
         ) {
           keyName = key;
-          value = elem.substring(kwObj[key][currentLanguage].length);
+          value = potentialValue;
           break;
         }
       } else if (
-        elem.toLowerCase().startsWith(kwObj[key]["en-US"].toLowerCase())
+        potentialKey.toLowerCase() === kwObj[key]["en-US"].toLowerCase()
       ) {
         keyName = key;
-        value = elem.substring(kwObj[key]["en-US"].length);
+        value = potentialValue;
         break;
       }
     }
@@ -159,14 +158,8 @@ export function decompileCustomGameSettingsDict(
     }
 
     if (keyName === null || value === null) {
-      error("No translation found for key of element '" + elem + "'");
+      error("No translation found for key of element '" + potentialKey + "'");
     }
-
-    if (!value.startsWith(":")) {
-      console.log(value);
-      error("Expected ':' after key in element '" + elem + "'");
-    }
-    value = value.substring(1).trim();
 
     if (isInvalidButAcceptedProperty) {
       continue;


### PR DESCRIPTION
This PR adds a missing setting for Roadhog's Take a Breather cooldown time and fixes some broken parsing caused by a rebase conflict being incorrectly resolved.
