### PR TITLE
fix: remove unneeded game mode settings check

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,7 @@
         "syntaxes/**",
         "LICENSE{,.txt}",
         "customGameSettingsSchema.json",
-        "language-configuration.json",
-        "decompilerui.html"
+        "language-configuration.json"
     ],
     "contributes": {
         "configuration": {

--- a/src/compiler/compiler.ts
+++ b/src/compiler/compiler.ts
@@ -403,10 +403,6 @@ export function compileCustomGameSettings(customGameSettings: Record<string, any
                         error("The gamemode '" + gamemode + "' is not available in OW2");
                     }
                 }
-                if (["control", "escort", "flashpoint", "hybrid", "push"].includes(gamemode)) {
-                    warn("w_dead_workshop", "The gamemode '" + gamemode + "' cannot be enabled from pasted settings and has been removed from the settings.");
-                    continue;
-                }
                 var wsGamemode = tows(gamemode, customGameSettingsSchema.gamemodes.values);
                 var isGamemodeEnabled = true;
                 if ("enabled" in customGameSettings.gamemodes[gamemode] && customGameSettings.gamemodes[gamemode].enabled === false) {

--- a/src/tests/customGameSettings.opy
+++ b/src/tests/customGameSettings.opy
@@ -16,6 +16,12 @@ settings {
             ],
             "captureSpeed%": 60
         },
+        "escort": {
+            "enabledMaps": [
+                "dorado"
+            ],
+            "payloadSpeed%": 200
+        },
         "general": {
             "gamemodeStartTrigger": "manual",
             "heroLimit": "off",

--- a/src/tests/results/customGameSettings.txt
+++ b/src/tests/results/customGameSettings.txt
@@ -21,6 +21,14 @@ settings
 			}
 			Capture Speed Modifier: 60%
 		}
+		Escort
+		{
+			enabled maps
+			{
+				Dorado
+			}
+			Payload Speed Modifier: 200%
+		}
 		General
 		{
 			Game Mode Start: Manual


### PR DESCRIPTION
This PR removes the check for game mode settings, as it is no longer bugged

Commits:
- **feat: re-enable core gamemode settings pasting**
- **build(vsce): ensure newer versions of vsce can properly package OverPy**
