### PR TITLE
feat: options to disable decompiler variable & subroutine index

### DIFF
--- a/src/decompiler/decompiler.ts
+++ b/src/decompiler/decompiler.ts
@@ -35,7 +35,10 @@ import { decompileActions, decompileConditions, decompileRuleToAst } from "./wor
 
 //OverPy Decompiler (Workshop -> OverPy)
 
-export function decompileAllRules(content: string, language: OWLanguage = "en-US") {
+export function decompileAllRules(content: string, language: OWLanguage = "en-US", options?: {
+    ignoreVariableIndex?: boolean,
+    ignoreSubroutineIndex?: boolean
+}) {
     resetGlobalVariables(language);
     var result = decompileAllRulesToAst(content);
 
@@ -59,7 +62,11 @@ export function decompileAllRules(content: string, language: OWLanguage = "en-US
         var globalVariableDeclarations = "";
         for (var variable of globalVariables) {
             if (defaultVarNames.indexOf(variable.name) !== variable.index) {
-                globalVariableDeclarations += "globalvar " + variable.name + " " + variable.index + "\n";
+                globalVariableDeclarations += "globalvar " + variable.name;
+                if (!options?.ignoreVariableIndex) {
+                    globalVariableDeclarations += " " + variable.index;
+                }
+                globalVariableDeclarations += "\n";
             }
         }
         if (globalVariableDeclarations !== "") {
@@ -71,7 +78,11 @@ export function decompileAllRules(content: string, language: OWLanguage = "en-US
         var playerVariableDeclarations = "";
         for (var variable of playerVariables) {
             if (defaultVarNames.indexOf(variable.name) !== variable.index) {
-                playerVariableDeclarations += "playervar " + variable.name + " " + variable.index + "\n";
+                playerVariableDeclarations += "playervar " + variable.name;
+                if (!options?.ignoreVariableIndex) {
+                    playerVariableDeclarations += " " + variable.index;
+                }
+                playerVariableDeclarations += "\n";
             }
         }
         if (playerVariableDeclarations !== "") {
@@ -84,7 +95,11 @@ export function decompileAllRules(content: string, language: OWLanguage = "en-US
         subroutines.sort((a, b) => a.index - b.index);
         for (var subroutine of subroutines) {
             if (defaultSubroutineNames.indexOf(subroutine.name) !== subroutine.index) {
-                subroutineDeclarations += "subroutine " + subroutine.name + " " + subroutine.index + "\n";
+                subroutineDeclarations += "subroutine " + subroutine.name;
+                if (!options?.ignoreSubroutineIndex) {
+                    subroutineDeclarations += " " + subroutine.index;
+                }
+                subroutineDeclarations += "\n";
             }
         }
         if (subroutineDeclarations !== "") {


### PR DESCRIPTION
This PR adds optional parameter `options` to the function `decompileAllRules`.

When decompiling, overpy will include the variable & subroutine indexes from the original workshop script. These indexes can conflict when appending the decompilation to another file. The `ignoreVariableIndex` and `ignoreSubroutineIndex` options have been added as a convenient way to remove those indexes. This is especially nice for automated workflows.

The `options` object could be extended to add additional decompiler settings if need be in the future.