### PR TITLE
feat: show diagnostics in vscode document

### DIFF
--- a/src/compiler/compiler.ts
+++ b/src/compiler/compiler.ts
@@ -33,7 +33,7 @@ import { astRulesToWs } from "./astToWorkshop";
 import { parseLines } from "./parser";
 import { Token, tokenize } from "./tokenizer";
 import { addVariable } from "../utils/varNames";
-import { AstConstantData, AstMacroData, MacroData, OWLanguage, ScriptFileStackMember, Subroutine, Variable } from "../types";
+import { AstConstantData, AstMacroData, CompilationDiagnostic, MacroData, OWLanguage, ScriptFileStackMember, Subroutine, Variable } from "../types";
 import { compileCustomGameSettingsDict } from "../utils/compilation";
 import { reinitInterpreter } from "../jsInterpreter";
 import PO from "pofile";
@@ -57,7 +57,7 @@ export async function compile(
     globalVariables: Variable[];
     playerVariables: Variable[];
     subroutines: Subroutine[];
-    encounteredWarnings: string[];
+    encounteredWarnings: CompilationDiagnostic[];
     hiddenWarnings: string[];
     enumMembers: Record<string, Record<string, Ast>>;
     nbElements: number;

--- a/src/globalVars.ts
+++ b/src/globalVars.ts
@@ -23,7 +23,7 @@ import { mapKw } from "./data/maps";
 import { opyKeywords } from "./data/opy/keywords";
 import { camelCaseToUpperCase } from "./utils/other";
 import { Constant, constantValues } from "./data/constants";
-import { AstConstantData, AstMacroData, FileStackMember, MacroData, Overwatch2Heroes, ow_languages, OWLanguage, ScriptFileStackMember, Subroutine, Type, Value, Variable } from "./types.d.js";
+import { AstConstantData, AstMacroData, CompilationDiagnostic, FileStackMember, MacroData, Overwatch2Heroes, ow_languages, OWLanguage, ScriptFileStackMember, Subroutine, Type, Value, Variable } from "./types.d.js";
 import { Ast, getAstForE, getAstForFalse, getAstForInfinity, getAstForNull, getAstForNullVector, getAstForNumber, getAstForTeamAll, getAstForTrue } from "./utils/ast";
 import { TranslatedString, TranslationLanguage } from "./compiler/translations";
 import { heroKw } from "./data/heroes";
@@ -116,7 +116,7 @@ export var astMacroLocalVariables: string[] = [];
 export const resetAstMacroLocalVariables = () => (astMacroLocalVariables = []);
 
 /** All warnings encountered during this compilation run. */
-export var encounteredWarnings: string[] = [];
+export var encounteredWarnings: CompilationDiagnostic[] = [];
 /** All warnings encountered during this compilation run that were either suppressed or otherwise ignored. */
 export let hiddenWarnings: string[] = [];
 /** A set of warning types that will not invoke a visible warning.

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -220,3 +220,9 @@ export type AstConstantData = {
     value: Ast;
     valueStr: string;
 }
+
+export type CompilationDiagnostic = {
+    message: string;
+    fileStack?: FileStackMember[];
+    severity: 'warning' | 'error';
+}


### PR DESCRIPTION
This PR adds the errors and warnings generated from the overpy compiler to the document's diagnostics list.

- The locations of errors and warnings are visible on the document.
- When the error is generated from inside a macro, the error will be displayed at the location of the macro call.
- Fixes bug in the `warn` function where the file stack is incorrectly inverted after adding a warning.

![image](https://github.com/user-attachments/assets/f5e3679a-de78-40c6-833c-0abe8d283d9c)
