### PR TITLE
chore: update workflows for fix tests failed

### DIFF
--- a/.github/workflows/behavior_test.yml
+++ b/.github/workflows/behavior_test.yml
@@ -12,19 +12,24 @@ jobs:
     test:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v6
-            - uses: actions/setup-node@v6
+            - name: Checkout
+              uses: actions/checkout@v6
+              with:
+                  fetch-depth: 0
+
+            - name: Setup pnpm
+              uses: pnpm/action-setup@v4
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v6
               with:
                   node-version: 22.4
-                  cache: npm
-            - uses: actions/cache/restore@v5
-              with:
-                  key: ${{ github.run_id }}-node-modules
-                  path: |
-                      node_modules
+                  cache: pnpm
+
             - name: Install dependencies
               run: |
-                  pnpm install
+                  pnpm i --frozen-lockfile
+
             - name: Run tests
               run: |
                   pnpm run test


### PR DESCRIPTION
This is a follow-up to the recent migration from npm to pnpm. I've noticed the behavior_test.yml workflow wasn't fully updated to use pnpm, which could cause caching issues and inconsistent installs.

Removes the now-redundant `actions/cache/restore` step since caching is handled by `setup-node`.



