### PR TITLE
fix(junkerQueen): update cooldown settings

### DIFF
--- a/src/data/customGameSettings.ts
+++ b/src/data/customGameSettings.ts
@@ -5269,7 +5269,6 @@ export const customGameSettingsSchema: CustomGameSettingSchema =
                         "doomfist",
                         "echo",
                         "freja",
-                        "junkerQueen",
                         "lucio",
                         "orisa",
                         "pharah",

--- a/src/tests/customGameSettings.opy
+++ b/src/tests/customGameSettings.opy
@@ -64,6 +64,9 @@ settings {
             "widowmaker": {
                 "damageDealt%": 120,
                 "ability1Cooldown%": 10
+            },
+            "junkerQueen": {
+                "secondaryFireCooldown%": 120
             }
         }
     }

--- a/src/tests/decompiler/z_1v1buildyourhero.txt
+++ b/src/tests/decompiler/z_1v1buildyourhero.txt
@@ -91,7 +91,7 @@ settings
 			Junker Queen
 			{
 				Commanding Shout Cooldown Time: 0%
-				Jagged Blade Cooldown Time: 62%
+				Jagged Blade Gracie Cooldown Time: 62%
 			}
 
 			Junkrat

--- a/src/tests/results/customGameSettings.txt
+++ b/src/tests/results/customGameSettings.txt
@@ -76,6 +76,10 @@ settings
 				Damage Dealt: 120%
 				Grappling Hook Cooldown Time: 10%
 			}
+			Junker Queen
+			{
+				Jagged Blade Gracie Cooldown Time: 120%
+			}
 		}
 	}
 }

--- a/src/tests/results/z_1v1buildyourhero.txt
+++ b/src/tests/results/z_1v1buildyourhero.txt
@@ -79,7 +79,7 @@ settings
 			Junker Queen
 			{
 				Commanding Shout Cooldown Time: 0%
-				Jagged Blade Cooldown Time: 62%
+				Jagged Blade Gracie Cooldown Time: 62%
 			}
 			Junkrat
 			{


### PR DESCRIPTION
This is a supplement to #425, as 425 is actually not yet completed 😂

- Removed "junkerQueen" from custom game settings `eachHero`.
- Added "junkerQueen" secondary fire cooldown setting in tests.
- Updated cooldown time decompiler and results files for consistency.