### PR TITLE
Regarding the issue discussed on Discord yesterday, I tried adding a postCompileHook

### DIFF
--- a/examples/cnserver/cn_server_test.opy
+++ b/examples/cnserver/cn_server_test.opy
@@ -1,0 +1,18 @@
+#!postCompileHook "script.js"
+settings {
+    "gamemodes": {
+        "skirmish": {
+            "enabledMaps": [
+                "workshopChamber"
+            ]
+        }
+    }
+}
+
+#Activated extensions
+#!extension projectiles
+
+rule "set player invis":
+    @Event eachPlayer
+
+    eventPlayer.setInvisibility(Invis.NONE)

--- a/examples/cnserver/script.js
+++ b/examples/cnserver/script.js
@@ -1,0 +1,16 @@
+
+/**
+ * 
+ * @param {string} content 
+ * @returns 
+ */
+function postCompileHook(content){
+    let resultText = content;
+    //DoSomething... Just an example
+    resultText = resultText.replace("弹道", "飞弹")
+    resultText = resultText.replace(/设置不可见\((.+?),\s全部禁用\);/g,
+        (match,first)=>`设置不可见(${first}, 无);`)
+
+    return String(resultText);
+}
+                

--- a/src/data/opy/preprocessing.ts
+++ b/src/data/opy/preprocessing.ts
@@ -205,6 +205,10 @@ You can specify \`noDetectionRule\` to not create the rule which sets the variab
     },
     "disableTranslationSourceLines": {
         "description": "If set, the source lines of the translations will not be included in the generated .po files. Use this if you are not actively translating your gamemode, to prevent cluttering git diffs."
+    },
+    "postCompileHook":{
+        "description": "It is a user-defined function that is executed after the script content has been compiled.",
+        "snippet": "postCompileHook \"script.js\""
     }
 };
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,7 +6,7 @@ import * as vscode from "vscode";
 // ! Yes, this sucks. Too bad!
 import { decompileAllRules } from "./decompiler/decompiler";
 import { compile } from "./compiler/compiler";
-import { postInitialLoad, rootPath, overpyTemplate } from "./globalVars";
+import { postInitialLoad, rootPath, overpyTemplate, postCompileHook, resetPostCompileHook } from "./globalVars";
 import { allFuncList, constantValuesCompLists, defaultCompList, fillAutocompletionAstMacros, fillAutocompletionConstants, fillAutocompletionEnums, fillAutocompletionMacros, fillAutocompletionSubroutines, fillAutocompletionVariables, memberCompletionItems, metaRuleParamsCompList, preprocessingDirectivesList, refreshAutoComplete, setActivatedExtensions, setAvailableExtensionPoints, setSpentExtensionPoints, stringEntitiesCompList } from "./autocomplete";
 import { Argument, CompilationDiagnostic, OWLanguage, ow_languages } from "./types.d";
 import { OpyError as OverpyError } from "./utils/logging";
@@ -81,7 +81,8 @@ export function activate(context: vscode.ExtensionContext) {
                 vscode.window.showWarningMessage(`Warning: ${warning.message}`);
             }
             applyCompilationDiagnostics(diagnostics, compileResult.encounteredWarnings);
-            vscode.env.clipboard.writeText(compileResult.result);
+            const postResult = postCompileHook(compileResult.result);
+            vscode.env.clipboard.writeText(postResult);
 
             const showElementCount = vscode.workspace.getConfiguration("overpy").showElementCountOnCompile;
             vscode.window.showInformationMessage(`Successfully compiled! (copied into clipboard${showElementCount ? `; ${compileResult.nbElements} elements` : ""})`);
@@ -95,6 +96,7 @@ export function activate(context: vscode.ExtensionContext) {
             setActivatedExtensions(compileResult.activatedExtensions);
             setSpentExtensionPoints(compileResult.spentExtensionPoints);
             setAvailableExtensionPoints(compileResult.availableExtensionPoints);
+            resetPostCompileHook();
             refreshAutoComplete();
         } catch (e) {
             if (e instanceof Error) {

--- a/src/globalVars.ts
+++ b/src/globalVars.ts
@@ -69,6 +69,11 @@ export const setMainFileName = (name: string) => (mainFileName = name);
 export var rootPath: string;
 export const setRootPath = (path: string) => (rootPath = path);
 
+//postCompileHook
+type PostCompileHook = (content: string) => string;
+export var postCompileHook:PostCompileHook = (c) => c;
+export var resetPostCompileHook = () => (postCompileHook = (c) => c);
+export var registerPostCompileHook = (hook: PostCompileHook) => (postCompileHook = hook); 
 //Global variables used to keep track of the name for the current array element/index.
 //Should be null at the beginning and end of each rule; if not, throws an error. (for compilation and decompilation)
 export var currentArrayElementName: string;


### PR DESCRIPTION
## Developers can declare `#!postCompileHook "script.js"` in the documentation

- to allow arbitrary modifications to the compiled output text. This is mainly intended to address certain translation errors that have not been fixed by Overwatch officials for a long time.

- I added a new folder named cnserver under the `examples` directory, which contains a` script.js` example and an `.opy` file.

- For the remaining changes, please refer to the changed files section.