### PR TITLE
fix: report accurate line numbers for unclosed bracket errors

### DIFF
--- a/src/compiler/tokenizer.ts
+++ b/src/compiler/tokenizer.ts
@@ -90,6 +90,10 @@ export function tokenize(content: string): LogicalLine[] {
 
     let i = 0;
 
+    // Track the fileStack position where the first unclosed bracket was opened
+    // This allows us to report accurate error locations instead of the current (modified) fileStack
+    let unclosedBracketFileStack: FileStackMember[] | undefined = undefined;
+
     function addToken(text: string) {
         if (text.length === 0) {
             error("Token is empty, lexer broke");
@@ -382,6 +386,11 @@ export function tokenize(content: string): LogicalLine[] {
         }
         if (content[i] === "(" || content[i] === "[" || content[i] === "{") {
             bracketsLevel++;
+            // Record the fileStack position when opening a bracket at level 0
+            // This is used to report accurate error locations for unclosed brackets
+            if (bracketsLevel === 1) {
+                unclosedBracketFileStack = getFileStackCopy();
+            }
             addToken(content[i]);
             continue;
         }
@@ -589,7 +598,9 @@ export function tokenize(content: string): LogicalLine[] {
     }
 
     if (bracketsLevel > 0) {
-        error("Found end of file, but a bracket isn't closed");
+        // Use the recorded fileStack to report accurate line numbers
+        // The current fileStack has been modified by moveCursor() during tokenization
+        error("Found end of file, but a bracket isn't closed", unclosedBracketFileStack);
     }
 
     if (DEBUG_MODE) {


### PR DESCRIPTION
Previously, when a bracket was not closed, the error message would display incorrect line numbers that could exceed the actual file length. This was caused by the fileStack being modified during tokenization by moveCursor(), which increments startLine as it processes content.

The fix records the fileStack position when the first unclosed bracket is opened (when bracketsLevel transitions from 0 to 1), and uses this recorded position when reporting the error instead of the modified fileStack.

Fixes issue where "bracket isn't closed" errors showed line numbers beyond the file's actual length, especially when using macros or multi-line content.

Changes:
- Add unclosedBracketFileStack variable to track bracket opening position
- Record fileStack snapshot when bracketsLevel becomes 1
- Use recorded position in error message at end of tokenization