### PR TITLE
fix(lsp): scope macro doc comments to the contiguous block above/inline

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -153,7 +153,6 @@ OverPyCompiler.prototype.parseLines = function(lines: LogicalLine[]): Ast[] {
                 value: value,
                 class_: class_,
                 valueStr: dispTokens(currentLine.tokens.slice(class_ ? 5 : 3), true),
-                comment: currentComments.length > 0 ? commentArrayToString(currentComments) : undefined,
             };
             currentComments = [];
             continue;
@@ -472,7 +471,6 @@ OverPyCompiler.prototype.parseLines = function(lines: LogicalLine[]): Ast[] {
                     lines: macroLines,
                     linesStr: childrenLines.map(x => " ".repeat(x.indentLevel) + dispTokens(x.tokens, true)),
                     args: macroArgs,
-                    comment: currentComments.length > 0 ? commentArrayToString(currentComments) : undefined,
                 };
 
                 //We do not care about macros in the AST

--- a/src/languageServer/completionState.ts
+++ b/src/languageServer/completionState.ts
@@ -174,8 +174,8 @@ export function updateCompletionStateFromCompileResult(
     };
 
     fillMacroCompletions(compileResult.macros);
-    fillAstMacroCompletions(Object.values(compileResult.astMacros));
-    fillAstConstantCompletions(Object.values(compileResult.astConstants));
+    fillAstMacroCompletions(Object.values(compileResult.astMacros), declarationDocs.macros);
+    fillAstConstantCompletions(Object.values(compileResult.astConstants), declarationDocs.macros);
     dynamicCompletionDataByUri.set(uri, dynamicCompletionData);
     refreshCompletionState();
 }
@@ -563,16 +563,17 @@ function fillMacroCompletions(macros: MacroData[]): void {
     }
 }
 
-function fillAstMacroCompletions(macros: AstMacroData[]): void {
+function fillAstMacroCompletions(macros: AstMacroData[], docs: Map<string, string>): void {
     dynamicCompletionData.normalAstMacros = {};
     dynamicCompletionData.memberAstMacros = {};
 
     for (const macro of macros) {
         let minIndent = Math.min(...macro.linesStr.map((line) => line.match(/^\s*/)![0].length));
+        const doc = docs.get((macro.class_ ?? "") + macro.name);
         const convertedMacro: CompletionData = {
             args: [],
             class: macro.class_,
-            description: `This macro resolves to:\n\n\`\`\`\n${macro.linesStr.map((line) => line.substring(minIndent)).join("\n")}\n\`\`\``,
+            description: `${doc ? doc + "\n\n" : ""}This macro resolves to:\n\n\`\`\`\n${macro.linesStr.map((line) => line.substring(minIndent)).join("\n")}\n\`\`\``,
         };
         let macroName = macro.name;
 
@@ -596,15 +597,16 @@ function fillAstMacroCompletions(macros: AstMacroData[]): void {
     }
 }
 
-function fillAstConstantCompletions(constants: AstConstantData[]): void {
+function fillAstConstantCompletions(constants: AstConstantData[], docs: Map<string, string>): void {
     dynamicCompletionData.normalAstConstants = {};
     dynamicCompletionData.memberAstConstants = {};
 
     for (const constant of constants) {
+        const doc = docs.get((constant.class_ ?? "") + constant.name);
         const convertedConstant: CompletionData = {
             args: null,
             class: constant.class_,
-            description: `This macro resolves to:\n\n\`\`\`\n${constant.valueStr}\n\`\`\``,
+            description: `${doc ? doc + "\n\n" : ""}This macro resolves to:\n\n\`\`\`\n${constant.valueStr}\n\`\`\``,
         };
 
         if (constant.class_) {

--- a/src/languageServer/declarationDocs.ts
+++ b/src/languageServer/declarationDocs.ts
@@ -1,8 +1,8 @@
 /**
  * Extracts documentation text from comments attached to user-defined declarations
- * (global/player variables, macros and enum members). A trailing comment on the same
- * line as the declaration is preferred; otherwise a contiguous comment block directly
- * above the declaration is used. `#!` directive lines are never treated as documentation.
+ * (global/player variables, macros and enum members). A contiguous comment block
+ * directly above the declaration and a trailing comment on the same line are merged
+ * (block first, inline appended). `#!` directive lines are never treated as documentation.
  */
 export type DeclarationDocs = {
     variables: Map<string, string>;
@@ -97,7 +97,12 @@ export function extractDeclarationDocs(text: string): DeclarationDocs {
 }
 
 function getDocFor(lines: string[], declarationIndex: number): string | null {
-    return getTrailingComment(lines[declarationIndex]) ?? getPrecedingComment(lines, declarationIndex);
+    const above = getPrecedingComment(lines, declarationIndex);
+    const inline = getTrailingComment(lines[declarationIndex]);
+    if (above && inline) {
+        return above + "\n" + inline;
+    }
+    return above ?? inline;
 }
 
 function getTrailingComment(line: string): string | null {

--- a/src/languageServer/declarationDocs.ts
+++ b/src/languageServer/declarationDocs.ts
@@ -100,7 +100,8 @@ function getDocFor(lines: string[], declarationIndex: number): string | null {
     const above = getPrecedingComment(lines, declarationIndex);
     const inline = getTrailingComment(lines[declarationIndex]);
     if (above && inline) {
-        return above + "\n" + inline;
+        // Two trailing spaces force a Markdown hard break so the popup keeps the line break.
+        return above + "  \n" + inline;
     }
     return above ?? inline;
 }
@@ -126,7 +127,8 @@ function getPrecedingComment(lines: string[], declarationIndex: number): string 
         collected.unshift(trimmed.slice(1).trim());
     }
 
-    return collected.length > 0 ? collected.join("\n") : null;
+    // Two trailing spaces force a Markdown hard break so each comment line renders separately.
+    return collected.length > 0 ? collected.join("  \n") : null;
 }
 
 function findCommentStart(line: string): { index: number; directive: boolean } | null {

--- a/src/languageServer/declarationDocs.ts
+++ b/src/languageServer/declarationDocs.ts
@@ -1,12 +1,13 @@
 /**
  * Extracts documentation text from comments attached to user-defined declarations
- * (global/player variables and enum members). A trailing comment on the same line as
- * the declaration is preferred; otherwise a contiguous comment block directly above
- * the declaration is used. `#!` directive lines are never treated as documentation.
+ * (global/player variables, macros and enum members). A trailing comment on the same
+ * line as the declaration is preferred; otherwise a contiguous comment block directly
+ * above the declaration is used. `#!` directive lines are never treated as documentation.
  */
 export type DeclarationDocs = {
     variables: Map<string, string>;
     subroutines: Map<string, string>;
+    macros: Map<string, string>;
     enums: Map<string, string>;
     enumMembers: Map<string, Map<string, string>>;
 };
@@ -15,6 +16,7 @@ export function emptyDeclarationDocs(): DeclarationDocs {
     return {
         variables: new Map(),
         subroutines: new Map(),
+        macros: new Map(),
         enums: new Map(),
         enumMembers: new Map(),
     };
@@ -52,6 +54,17 @@ export function extractDeclarationDocs(text: string): DeclarationDocs {
             const doc = getDocFor(lines, index);
             if (doc) {
                 docs.subroutines.set(subroutineMatch[1], doc);
+            }
+            continue;
+        }
+
+        // Matches `macro NAME = value` constants and `macro NAME(...)` function macros,
+        // including member forms like `macro Class.member = ...`.
+        const macroMatch = line.match(/^\s*macro\s+([A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)?)\s*(?:\(|=)/);
+        if (macroMatch) {
+            const doc = getDocFor(lines, index);
+            if (doc) {
+                docs.macros.set(macroMatch[1], doc);
             }
             continue;
         }

--- a/src/test/languageServer.test.ts
+++ b/src/test/languageServer.test.ts
@@ -106,8 +106,8 @@ async function main(): Promise<void> {
             "# unrelated section header",
             "",
             "macro SCORE_STEP = 1",
-            "# above that should lose",
-            "macro BOTH = 3 # inline wins",
+            "# above note",
+            "macro BOTH = 3 # inline note",
             "# doc for helper",
             "macro helper():",
             "    pass",
@@ -120,8 +120,8 @@ async function main(): Promise<void> {
     assert.equal(macroDocs.macros.get("MAX_PLAYERS"), "Max team size");
     // A blank line between the comment and the macro breaks the block (the bug).
     assert.equal(macroDocs.macros.get("SCORE_STEP"), undefined);
-    // Inline trailing comment wins over the comment above.
-    assert.equal(macroDocs.macros.get("BOTH"), "inline wins");
+    // Above block and inline comment are merged, block first.
+    assert.equal(macroDocs.macros.get("BOTH"), "above note\ninline note");
     // Function macro picks up its contiguous comment...
     assert.equal(macroDocs.macros.get("helper"), "doc for helper");
     // ...and does not leak onto the following declaration.

--- a/src/test/languageServer.test.ts
+++ b/src/test/languageServer.test.ts
@@ -98,6 +98,37 @@ async function main(): Promise<void> {
     assert.equal(declarationDocs.enumMembers.get("GameStatus")?.get("SETUP"), "Waiting for players to join");
     assert.equal(declarationDocs.enumMembers.get("GameStatus")?.get("PLAYING"), "Match is live");
 
+    const macroDocs = extractDeclarationDocs(
+        [
+            "# Max team size",
+            "macro MAX_PLAYERS = 5",
+            "",
+            "# unrelated section header",
+            "",
+            "macro SCORE_STEP = 1",
+            "# above that should lose",
+            "macro BOTH = 3 # inline wins",
+            "# doc for helper",
+            "macro helper():",
+            "    pass",
+            "macro AFTER = 9",
+            "# member macro doc",
+            "macro Foo.bar = 7",
+        ].join("\n"),
+    );
+    // Contiguous comment directly above attaches.
+    assert.equal(macroDocs.macros.get("MAX_PLAYERS"), "Max team size");
+    // A blank line between the comment and the macro breaks the block (the bug).
+    assert.equal(macroDocs.macros.get("SCORE_STEP"), undefined);
+    // Inline trailing comment wins over the comment above.
+    assert.equal(macroDocs.macros.get("BOTH"), "inline wins");
+    // Function macro picks up its contiguous comment...
+    assert.equal(macroDocs.macros.get("helper"), "doc for helper");
+    // ...and does not leak onto the following declaration.
+    assert.equal(macroDocs.macros.get("AFTER"), undefined);
+    // Member macros are keyed by their full name.
+    assert.equal(macroDocs.macros.get("Foo.bar"), "member macro doc");
+
     const annotationDocument = TextDocument.create("file:///tmp/test.opy", "overpy", 1, "rule \"hello\":\n    @");
     const annotationCompletions = getCompletionList(annotationDocument, { line: 1, character: 5 }, "@");
     assert.ok(annotationCompletions.items.some((item) => item.label === "@Event"));
@@ -728,6 +759,34 @@ async function main(): Promise<void> {
     const playingItem = enumMemberCompletions.items.find((item) => item.label === "PLAYING");
     assert.ok(playingItem);
     assert.match(getDocumentationValue(playingItem), /Match is live/);
+
+    const macroDocsDocument = TextDocument.create(
+        "file:///tmp/macros.opy",
+        "overpy",
+        1,
+        [
+            "globalvar score",
+            "# Points awarded per kill",
+            "macro KILL_POINTS = 100",
+            "",
+            "# unrelated header",
+            "",
+            "macro RESPAWN_TIME = 5",
+            "rule \"r\":",
+            "    @Event global",
+            "    score = KILL_POINTS",
+            "    wait(RESPAWN_TIME, Wait.IGNORE_CONDITION)",
+        ].join("\n"),
+    );
+    await validateTextDocument(macroDocsDocument, "en-US");
+
+    const killPointsHover = getHover(macroDocsDocument, { line: 9, character: "    score = KIL".length });
+    assert.ok(killPointsHover);
+    assert.match(getHoverText(killPointsHover), /Points awarded per kill/);
+
+    const respawnHover = getHover(macroDocsDocument, { line: 10, character: "    wait(RESPAW".length });
+    assert.ok(respawnHover);
+    assert.doesNotMatch(getHoverText(respawnHover), /unrelated header/, "a blank line should break the comment block");
 
     console.log("LSP adapter tests passed");
 }

--- a/src/test/languageServer.test.ts
+++ b/src/test/languageServer.test.ts
@@ -120,8 +120,8 @@ async function main(): Promise<void> {
     assert.equal(macroDocs.macros.get("MAX_PLAYERS"), "Max team size");
     // A blank line between the comment and the macro breaks the block (the bug).
     assert.equal(macroDocs.macros.get("SCORE_STEP"), undefined);
-    // Above block and inline comment are merged, block first.
-    assert.equal(macroDocs.macros.get("BOTH"), "above note\ninline note");
+    // Above block and inline comment are merged, block first, with a Markdown hard break.
+    assert.equal(macroDocs.macros.get("BOTH"), "above note  \ninline note");
     // Function macro picks up its contiguous comment...
     assert.equal(macroDocs.macros.get("helper"), "doc for helper");
     // ...and does not leak onto the following declaration.

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -223,7 +223,6 @@ export type AstMacroData = {
     lines: Ast[];
     linesStr: string[];
     class_?: string;
-    comment?: string;
     args: {
         name: string;
         default?: Ast;
@@ -237,7 +236,6 @@ export type AstConstantData = {
     class_?: string;
     value: Ast;
     valueStr: string;
-    comment?: string;
 }
 
 export type CompilationDiagnostic = {


### PR DESCRIPTION
Extract macro/constant docs through declarationDocs (break on blank or non-comment lines, inline wins) instead of the parser's running accumulator, which grabbed unrelated comments far above the macro.