### PR TITLE
feat(settings): add Shion custom settings

### DIFF
--- a/customGameSettingsSchema.json
+++ b/customGameSettingsSchema.json
@@ -19265,6 +19265,108 @@
                                 }
                             }
                         },
+                        "shion": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "ability1Distance%": {
+                                    "type": "number"
+                                },
+                                "ability2Kb%": {
+                                    "type": "number"
+                                },
+                                "ability2Duration%": {
+                                    "type": "number"
+                                },
+                                "ability2Speed%": {
+                                    "type": "number"
+                                },
+                                "enableMelee": {
+                                    "type": "boolean"
+                                },
+                                "enableSpawningWithUlt": {
+                                    "type": "boolean"
+                                },
+                                "enableInfiniteUlt": {
+                                    "type": "boolean"
+                                },
+                                "damageDealt%": {
+                                    "type": "number"
+                                },
+                                "damageReceived%": {
+                                    "type": "number"
+                                },
+                                "healingDealt%": {
+                                    "type": "number"
+                                },
+                                "healingReceived%": {
+                                    "type": "number"
+                                },
+                                "health%": {
+                                    "type": "number"
+                                },
+                                "jumpVerticalSpeed%": {
+                                    "type": "number"
+                                },
+                                "movementGravity%": {
+                                    "type": "number"
+                                },
+                                "movementSpeed%": {
+                                    "type": "number"
+                                },
+                                "projectileGravity%": {
+                                    "type": "number"
+                                },
+                                "projectileSpeed%": {
+                                    "type": "number"
+                                },
+                                "enableHeadshotsOnly": {
+                                    "type": "boolean"
+                                },
+                                "enablePrimaryFire": {
+                                    "type": "boolean"
+                                },
+                                "ammoClipSize%": {
+                                    "type": "number"
+                                },
+                                "enableInfiniteAmmo": {
+                                    "type": "boolean"
+                                },
+                                "passiveHealthRegen": {
+                                    "type": "boolean"
+                                },
+                                "enableRolePassive": {
+                                    "type": "boolean"
+                                },
+                                "enableAbility1": {
+                                    "type": "boolean"
+                                },
+                                "ability1Cooldown%": {
+                                    "type": "number"
+                                },
+                                "enableAbility2": {
+                                    "type": "boolean"
+                                },
+                                "ability2Cooldown%": {
+                                    "type": "number"
+                                },
+                                "ultGen%": {
+                                    "type": "number"
+                                },
+                                "combatUltGen%": {
+                                    "type": "number"
+                                },
+                                "passiveUltGen%": {
+                                    "type": "number"
+                                },
+                                "enableUlt": {
+                                    "type": "boolean"
+                                },
+                                "secondaryFireCooldown%": {
+                                    "type": "number"
+                                }
+                            }
+                        },
                         "sierra": {
                             "type": "object",
                             "additionalProperties": false,
@@ -21254,90 +21356,6 @@
                                     "type": "number"
                                 },
                                 "movementSpeed%": {
-                                    "type": "number"
-                                },
-                                "enableHeadshotsOnly": {
-                                    "type": "boolean"
-                                },
-                                "enablePrimaryFire": {
-                                    "type": "boolean"
-                                },
-                                "ammoClipSize%": {
-                                    "type": "number"
-                                },
-                                "enableInfiniteAmmo": {
-                                    "type": "boolean"
-                                },
-                                "passiveHealthRegen": {
-                                    "type": "boolean"
-                                },
-                                "enableRolePassive": {
-                                    "type": "boolean"
-                                },
-                                "enableAbility1": {
-                                    "type": "boolean"
-                                },
-                                "ability1Cooldown%": {
-                                    "type": "number"
-                                },
-                                "enableAbility2": {
-                                    "type": "boolean"
-                                },
-                                "ability2Cooldown%": {
-                                    "type": "number"
-                                },
-                                "ultGen%": {
-                                    "type": "number"
-                                },
-                                "combatUltGen%": {
-                                    "type": "number"
-                                },
-                                "passiveUltGen%": {
-                                    "type": "number"
-                                },
-                                "enableUlt": {
-                                    "type": "boolean"
-                                }
-                            }
-                        },
-                        "shion": {
-                            "type": "object",
-                            "additionalProperties": false,
-                            "properties": {
-                                "enableMelee": {
-                                    "type": "boolean"
-                                },
-                                "enableSpawningWithUlt": {
-                                    "type": "boolean"
-                                },
-                                "damageDealt%": {
-                                    "type": "number"
-                                },
-                                "damageReceived%": {
-                                    "type": "number"
-                                },
-                                "healingDealt%": {
-                                    "type": "number"
-                                },
-                                "healingReceived%": {
-                                    "type": "number"
-                                },
-                                "health%": {
-                                    "type": "number"
-                                },
-                                "jumpVerticalSpeed%": {
-                                    "type": "number"
-                                },
-                                "movementGravity%": {
-                                    "type": "number"
-                                },
-                                "movementSpeed%": {
-                                    "type": "number"
-                                },
-                                "projectileGravity%": {
-                                    "type": "number"
-                                },
-                                "projectileSpeed%": {
                                     "type": "number"
                                 },
                                 "enableHeadshotsOnly": {
@@ -24338,6 +24356,108 @@
                                 }
                             }
                         },
+                        "shion": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "ability1Distance%": {
+                                    "type": "number"
+                                },
+                                "ability2Kb%": {
+                                    "type": "number"
+                                },
+                                "ability2Duration%": {
+                                    "type": "number"
+                                },
+                                "ability2Speed%": {
+                                    "type": "number"
+                                },
+                                "enableMelee": {
+                                    "type": "boolean"
+                                },
+                                "enableSpawningWithUlt": {
+                                    "type": "boolean"
+                                },
+                                "enableInfiniteUlt": {
+                                    "type": "boolean"
+                                },
+                                "damageDealt%": {
+                                    "type": "number"
+                                },
+                                "damageReceived%": {
+                                    "type": "number"
+                                },
+                                "healingDealt%": {
+                                    "type": "number"
+                                },
+                                "healingReceived%": {
+                                    "type": "number"
+                                },
+                                "health%": {
+                                    "type": "number"
+                                },
+                                "jumpVerticalSpeed%": {
+                                    "type": "number"
+                                },
+                                "movementGravity%": {
+                                    "type": "number"
+                                },
+                                "movementSpeed%": {
+                                    "type": "number"
+                                },
+                                "projectileGravity%": {
+                                    "type": "number"
+                                },
+                                "projectileSpeed%": {
+                                    "type": "number"
+                                },
+                                "enableHeadshotsOnly": {
+                                    "type": "boolean"
+                                },
+                                "enablePrimaryFire": {
+                                    "type": "boolean"
+                                },
+                                "ammoClipSize%": {
+                                    "type": "number"
+                                },
+                                "enableInfiniteAmmo": {
+                                    "type": "boolean"
+                                },
+                                "passiveHealthRegen": {
+                                    "type": "boolean"
+                                },
+                                "enableRolePassive": {
+                                    "type": "boolean"
+                                },
+                                "enableAbility1": {
+                                    "type": "boolean"
+                                },
+                                "ability1Cooldown%": {
+                                    "type": "number"
+                                },
+                                "enableAbility2": {
+                                    "type": "boolean"
+                                },
+                                "ability2Cooldown%": {
+                                    "type": "number"
+                                },
+                                "ultGen%": {
+                                    "type": "number"
+                                },
+                                "combatUltGen%": {
+                                    "type": "number"
+                                },
+                                "passiveUltGen%": {
+                                    "type": "number"
+                                },
+                                "enableUlt": {
+                                    "type": "boolean"
+                                },
+                                "secondaryFireCooldown%": {
+                                    "type": "number"
+                                }
+                            }
+                        },
                         "sierra": {
                             "type": "object",
                             "additionalProperties": false,
@@ -26327,90 +26447,6 @@
                                     "type": "number"
                                 },
                                 "movementSpeed%": {
-                                    "type": "number"
-                                },
-                                "enableHeadshotsOnly": {
-                                    "type": "boolean"
-                                },
-                                "enablePrimaryFire": {
-                                    "type": "boolean"
-                                },
-                                "ammoClipSize%": {
-                                    "type": "number"
-                                },
-                                "enableInfiniteAmmo": {
-                                    "type": "boolean"
-                                },
-                                "passiveHealthRegen": {
-                                    "type": "boolean"
-                                },
-                                "enableRolePassive": {
-                                    "type": "boolean"
-                                },
-                                "enableAbility1": {
-                                    "type": "boolean"
-                                },
-                                "ability1Cooldown%": {
-                                    "type": "number"
-                                },
-                                "enableAbility2": {
-                                    "type": "boolean"
-                                },
-                                "ability2Cooldown%": {
-                                    "type": "number"
-                                },
-                                "ultGen%": {
-                                    "type": "number"
-                                },
-                                "combatUltGen%": {
-                                    "type": "number"
-                                },
-                                "passiveUltGen%": {
-                                    "type": "number"
-                                },
-                                "enableUlt": {
-                                    "type": "boolean"
-                                }
-                            }
-                        },
-                        "shion": {
-                            "type": "object",
-                            "additionalProperties": false,
-                            "properties": {
-                                "enableMelee": {
-                                    "type": "boolean"
-                                },
-                                "enableSpawningWithUlt": {
-                                    "type": "boolean"
-                                },
-                                "damageDealt%": {
-                                    "type": "number"
-                                },
-                                "damageReceived%": {
-                                    "type": "number"
-                                },
-                                "healingDealt%": {
-                                    "type": "number"
-                                },
-                                "healingReceived%": {
-                                    "type": "number"
-                                },
-                                "health%": {
-                                    "type": "number"
-                                },
-                                "jumpVerticalSpeed%": {
-                                    "type": "number"
-                                },
-                                "movementGravity%": {
-                                    "type": "number"
-                                },
-                                "movementSpeed%": {
-                                    "type": "number"
-                                },
-                                "projectileGravity%": {
-                                    "type": "number"
-                                },
-                                "projectileSpeed%": {
                                     "type": "number"
                                 },
                                 "enableHeadshotsOnly": {
@@ -29411,6 +29447,108 @@
                                 }
                             }
                         },
+                        "shion": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "ability1Distance%": {
+                                    "type": "number"
+                                },
+                                "ability2Kb%": {
+                                    "type": "number"
+                                },
+                                "ability2Duration%": {
+                                    "type": "number"
+                                },
+                                "ability2Speed%": {
+                                    "type": "number"
+                                },
+                                "enableMelee": {
+                                    "type": "boolean"
+                                },
+                                "enableSpawningWithUlt": {
+                                    "type": "boolean"
+                                },
+                                "enableInfiniteUlt": {
+                                    "type": "boolean"
+                                },
+                                "damageDealt%": {
+                                    "type": "number"
+                                },
+                                "damageReceived%": {
+                                    "type": "number"
+                                },
+                                "healingDealt%": {
+                                    "type": "number"
+                                },
+                                "healingReceived%": {
+                                    "type": "number"
+                                },
+                                "health%": {
+                                    "type": "number"
+                                },
+                                "jumpVerticalSpeed%": {
+                                    "type": "number"
+                                },
+                                "movementGravity%": {
+                                    "type": "number"
+                                },
+                                "movementSpeed%": {
+                                    "type": "number"
+                                },
+                                "projectileGravity%": {
+                                    "type": "number"
+                                },
+                                "projectileSpeed%": {
+                                    "type": "number"
+                                },
+                                "enableHeadshotsOnly": {
+                                    "type": "boolean"
+                                },
+                                "enablePrimaryFire": {
+                                    "type": "boolean"
+                                },
+                                "ammoClipSize%": {
+                                    "type": "number"
+                                },
+                                "enableInfiniteAmmo": {
+                                    "type": "boolean"
+                                },
+                                "passiveHealthRegen": {
+                                    "type": "boolean"
+                                },
+                                "enableRolePassive": {
+                                    "type": "boolean"
+                                },
+                                "enableAbility1": {
+                                    "type": "boolean"
+                                },
+                                "ability1Cooldown%": {
+                                    "type": "number"
+                                },
+                                "enableAbility2": {
+                                    "type": "boolean"
+                                },
+                                "ability2Cooldown%": {
+                                    "type": "number"
+                                },
+                                "ultGen%": {
+                                    "type": "number"
+                                },
+                                "combatUltGen%": {
+                                    "type": "number"
+                                },
+                                "passiveUltGen%": {
+                                    "type": "number"
+                                },
+                                "enableUlt": {
+                                    "type": "boolean"
+                                },
+                                "secondaryFireCooldown%": {
+                                    "type": "number"
+                                }
+                            }
+                        },
                         "sierra": {
                             "type": "object",
                             "additionalProperties": false,
@@ -31400,90 +31538,6 @@
                                     "type": "number"
                                 },
                                 "movementSpeed%": {
-                                    "type": "number"
-                                },
-                                "enableHeadshotsOnly": {
-                                    "type": "boolean"
-                                },
-                                "enablePrimaryFire": {
-                                    "type": "boolean"
-                                },
-                                "ammoClipSize%": {
-                                    "type": "number"
-                                },
-                                "enableInfiniteAmmo": {
-                                    "type": "boolean"
-                                },
-                                "passiveHealthRegen": {
-                                    "type": "boolean"
-                                },
-                                "enableRolePassive": {
-                                    "type": "boolean"
-                                },
-                                "enableAbility1": {
-                                    "type": "boolean"
-                                },
-                                "ability1Cooldown%": {
-                                    "type": "number"
-                                },
-                                "enableAbility2": {
-                                    "type": "boolean"
-                                },
-                                "ability2Cooldown%": {
-                                    "type": "number"
-                                },
-                                "ultGen%": {
-                                    "type": "number"
-                                },
-                                "combatUltGen%": {
-                                    "type": "number"
-                                },
-                                "passiveUltGen%": {
-                                    "type": "number"
-                                },
-                                "enableUlt": {
-                                    "type": "boolean"
-                                }
-                            }
-                        },
-                        "shion": {
-                            "type": "object",
-                            "additionalProperties": false,
-                            "properties": {
-                                "enableMelee": {
-                                    "type": "boolean"
-                                },
-                                "enableSpawningWithUlt": {
-                                    "type": "boolean"
-                                },
-                                "damageDealt%": {
-                                    "type": "number"
-                                },
-                                "damageReceived%": {
-                                    "type": "number"
-                                },
-                                "healingDealt%": {
-                                    "type": "number"
-                                },
-                                "healingReceived%": {
-                                    "type": "number"
-                                },
-                                "health%": {
-                                    "type": "number"
-                                },
-                                "jumpVerticalSpeed%": {
-                                    "type": "number"
-                                },
-                                "movementGravity%": {
-                                    "type": "number"
-                                },
-                                "movementSpeed%": {
-                                    "type": "number"
-                                },
-                                "projectileGravity%": {
-                                    "type": "number"
-                                },
-                                "projectileSpeed%": {
                                     "type": "number"
                                 },
                                 "enableHeadshotsOnly": {
@@ -34484,6 +34538,108 @@
                                 }
                             }
                         },
+                        "shion": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "ability1Distance%": {
+                                    "type": "number"
+                                },
+                                "ability2Kb%": {
+                                    "type": "number"
+                                },
+                                "ability2Duration%": {
+                                    "type": "number"
+                                },
+                                "ability2Speed%": {
+                                    "type": "number"
+                                },
+                                "enableMelee": {
+                                    "type": "boolean"
+                                },
+                                "enableSpawningWithUlt": {
+                                    "type": "boolean"
+                                },
+                                "enableInfiniteUlt": {
+                                    "type": "boolean"
+                                },
+                                "damageDealt%": {
+                                    "type": "number"
+                                },
+                                "damageReceived%": {
+                                    "type": "number"
+                                },
+                                "healingDealt%": {
+                                    "type": "number"
+                                },
+                                "healingReceived%": {
+                                    "type": "number"
+                                },
+                                "health%": {
+                                    "type": "number"
+                                },
+                                "jumpVerticalSpeed%": {
+                                    "type": "number"
+                                },
+                                "movementGravity%": {
+                                    "type": "number"
+                                },
+                                "movementSpeed%": {
+                                    "type": "number"
+                                },
+                                "projectileGravity%": {
+                                    "type": "number"
+                                },
+                                "projectileSpeed%": {
+                                    "type": "number"
+                                },
+                                "enableHeadshotsOnly": {
+                                    "type": "boolean"
+                                },
+                                "enablePrimaryFire": {
+                                    "type": "boolean"
+                                },
+                                "ammoClipSize%": {
+                                    "type": "number"
+                                },
+                                "enableInfiniteAmmo": {
+                                    "type": "boolean"
+                                },
+                                "passiveHealthRegen": {
+                                    "type": "boolean"
+                                },
+                                "enableRolePassive": {
+                                    "type": "boolean"
+                                },
+                                "enableAbility1": {
+                                    "type": "boolean"
+                                },
+                                "ability1Cooldown%": {
+                                    "type": "number"
+                                },
+                                "enableAbility2": {
+                                    "type": "boolean"
+                                },
+                                "ability2Cooldown%": {
+                                    "type": "number"
+                                },
+                                "ultGen%": {
+                                    "type": "number"
+                                },
+                                "combatUltGen%": {
+                                    "type": "number"
+                                },
+                                "passiveUltGen%": {
+                                    "type": "number"
+                                },
+                                "enableUlt": {
+                                    "type": "boolean"
+                                },
+                                "secondaryFireCooldown%": {
+                                    "type": "number"
+                                }
+                            }
+                        },
                         "sierra": {
                             "type": "object",
                             "additionalProperties": false,
@@ -36473,90 +36629,6 @@
                                     "type": "number"
                                 },
                                 "movementSpeed%": {
-                                    "type": "number"
-                                },
-                                "enableHeadshotsOnly": {
-                                    "type": "boolean"
-                                },
-                                "enablePrimaryFire": {
-                                    "type": "boolean"
-                                },
-                                "ammoClipSize%": {
-                                    "type": "number"
-                                },
-                                "enableInfiniteAmmo": {
-                                    "type": "boolean"
-                                },
-                                "passiveHealthRegen": {
-                                    "type": "boolean"
-                                },
-                                "enableRolePassive": {
-                                    "type": "boolean"
-                                },
-                                "enableAbility1": {
-                                    "type": "boolean"
-                                },
-                                "ability1Cooldown%": {
-                                    "type": "number"
-                                },
-                                "enableAbility2": {
-                                    "type": "boolean"
-                                },
-                                "ability2Cooldown%": {
-                                    "type": "number"
-                                },
-                                "ultGen%": {
-                                    "type": "number"
-                                },
-                                "combatUltGen%": {
-                                    "type": "number"
-                                },
-                                "passiveUltGen%": {
-                                    "type": "number"
-                                },
-                                "enableUlt": {
-                                    "type": "boolean"
-                                }
-                            }
-                        },
-                        "shion": {
-                            "type": "object",
-                            "additionalProperties": false,
-                            "properties": {
-                                "enableMelee": {
-                                    "type": "boolean"
-                                },
-                                "enableSpawningWithUlt": {
-                                    "type": "boolean"
-                                },
-                                "damageDealt%": {
-                                    "type": "number"
-                                },
-                                "damageReceived%": {
-                                    "type": "number"
-                                },
-                                "healingDealt%": {
-                                    "type": "number"
-                                },
-                                "healingReceived%": {
-                                    "type": "number"
-                                },
-                                "health%": {
-                                    "type": "number"
-                                },
-                                "jumpVerticalSpeed%": {
-                                    "type": "number"
-                                },
-                                "movementGravity%": {
-                                    "type": "number"
-                                },
-                                "movementSpeed%": {
-                                    "type": "number"
-                                },
-                                "projectileGravity%": {
-                                    "type": "number"
-                                },
-                                "projectileSpeed%": {
                                     "type": "number"
                                 },
                                 "enableHeadshotsOnly": {
@@ -39688,6 +39760,108 @@
                         }
                     }
                 },
+                "shion": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "ability1Distance%": {
+                            "type": "number"
+                        },
+                        "ability2Kb%": {
+                            "type": "number"
+                        },
+                        "ability2Duration%": {
+                            "type": "number"
+                        },
+                        "ability2Speed%": {
+                            "type": "number"
+                        },
+                        "enableMelee": {
+                            "type": "boolean"
+                        },
+                        "enableSpawningWithUlt": {
+                            "type": "boolean"
+                        },
+                        "enableInfiniteUlt": {
+                            "type": "boolean"
+                        },
+                        "damageDealt%": {
+                            "type": "number"
+                        },
+                        "damageReceived%": {
+                            "type": "number"
+                        },
+                        "healingDealt%": {
+                            "type": "number"
+                        },
+                        "healingReceived%": {
+                            "type": "number"
+                        },
+                        "health%": {
+                            "type": "number"
+                        },
+                        "jumpVerticalSpeed%": {
+                            "type": "number"
+                        },
+                        "movementGravity%": {
+                            "type": "number"
+                        },
+                        "movementSpeed%": {
+                            "type": "number"
+                        },
+                        "projectileGravity%": {
+                            "type": "number"
+                        },
+                        "projectileSpeed%": {
+                            "type": "number"
+                        },
+                        "enableHeadshotsOnly": {
+                            "type": "boolean"
+                        },
+                        "enablePrimaryFire": {
+                            "type": "boolean"
+                        },
+                        "ammoClipSize%": {
+                            "type": "number"
+                        },
+                        "enableInfiniteAmmo": {
+                            "type": "boolean"
+                        },
+                        "passiveHealthRegen": {
+                            "type": "boolean"
+                        },
+                        "enableRolePassive": {
+                            "type": "boolean"
+                        },
+                        "enableAbility1": {
+                            "type": "boolean"
+                        },
+                        "ability1Cooldown%": {
+                            "type": "number"
+                        },
+                        "enableAbility2": {
+                            "type": "boolean"
+                        },
+                        "ability2Cooldown%": {
+                            "type": "number"
+                        },
+                        "ultGen%": {
+                            "type": "number"
+                        },
+                        "combatUltGen%": {
+                            "type": "number"
+                        },
+                        "passiveUltGen%": {
+                            "type": "number"
+                        },
+                        "enableUlt": {
+                            "type": "boolean"
+                        },
+                        "secondaryFireCooldown%": {
+                            "type": "number"
+                        }
+                    }
+                },
                 "sierra": {
                     "type": "object",
                     "additionalProperties": false,
@@ -41677,90 +41851,6 @@
                             "type": "number"
                         },
                         "movementSpeed%": {
-                            "type": "number"
-                        },
-                        "enableHeadshotsOnly": {
-                            "type": "boolean"
-                        },
-                        "enablePrimaryFire": {
-                            "type": "boolean"
-                        },
-                        "ammoClipSize%": {
-                            "type": "number"
-                        },
-                        "enableInfiniteAmmo": {
-                            "type": "boolean"
-                        },
-                        "passiveHealthRegen": {
-                            "type": "boolean"
-                        },
-                        "enableRolePassive": {
-                            "type": "boolean"
-                        },
-                        "enableAbility1": {
-                            "type": "boolean"
-                        },
-                        "ability1Cooldown%": {
-                            "type": "number"
-                        },
-                        "enableAbility2": {
-                            "type": "boolean"
-                        },
-                        "ability2Cooldown%": {
-                            "type": "number"
-                        },
-                        "ultGen%": {
-                            "type": "number"
-                        },
-                        "combatUltGen%": {
-                            "type": "number"
-                        },
-                        "passiveUltGen%": {
-                            "type": "number"
-                        },
-                        "enableUlt": {
-                            "type": "boolean"
-                        }
-                    }
-                },
-                "shion": {
-                    "type": "object",
-                    "additionalProperties": false,
-                    "properties": {
-                        "enableMelee": {
-                            "type": "boolean"
-                        },
-                        "enableSpawningWithUlt": {
-                            "type": "boolean"
-                        },
-                        "damageDealt%": {
-                            "type": "number"
-                        },
-                        "damageReceived%": {
-                            "type": "number"
-                        },
-                        "healingDealt%": {
-                            "type": "number"
-                        },
-                        "healingReceived%": {
-                            "type": "number"
-                        },
-                        "health%": {
-                            "type": "number"
-                        },
-                        "jumpVerticalSpeed%": {
-                            "type": "number"
-                        },
-                        "movementGravity%": {
-                            "type": "number"
-                        },
-                        "movementSpeed%": {
-                            "type": "number"
-                        },
-                        "projectileGravity%": {
-                            "type": "number"
-                        },
-                        "projectileSpeed%": {
                             "type": "number"
                         },
                         "enableHeadshotsOnly": {

--- a/out/overpy_standalone.js
+++ b/out/overpy_standalone.js
@@ -17211,16 +17211,23 @@ var heroKw = (
       "tr-TR": "Roadhog"
     },
     "shion": {
+      "secondaryFire": {
+        "en-US": "Execution",
+        "zh-CN": "\u4EA4\u53C9\u67AA\u51B3"
+      },
       "ability1": {
-        "en-US": "Evade"
+        "en-US": "Evade",
+        "zh-CN": "\u673A\u52A8\u95EA\u907F"
       },
       "ability2": {
-        "en-US": "Joyride"
+        "en-US": "Joyride",
+        "zh-CN": "\u7EB5\u60C5\u72C2\u98D9"
       },
       "ultimate": {
         "en-US": "Satsuriku Spree"
       },
-      "en-US": "Shion"
+      "en-US": "Shion",
+      "zh-CN": "\u6B7B\u6028"
     },
     "sierra": {
       "secondaryFire": {
@@ -42160,7 +42167,8 @@ var customGameSettingsSchema = (
               "winston",
               "wreckingBall",
               "ramattra",
-              "venture"
+              "venture",
+              "shion"
             ],
             "guid": "000000007672",
             "en-US": "Infinite Ultimate Duration",
@@ -42836,7 +42844,8 @@ var customGameSettingsSchema = (
               "ramattra",
               "lifeweaver",
               "venture",
-              "juno"
+              "juno",
+              "shion"
             ],
             "en-US": "%1$s Cooldown Time",
             "de-DE": "%1$s \u2013 Abklingzeit",
@@ -44358,6 +44367,30 @@ var customGameSettingsSchema = (
               "tr-TR": "Domuz \xC7evirme Geri \u0130tme Skaleri",
               "zh-CN": "\u9E21\u98DE\u72D7\u8DF3\u51FB\u9000\u500D\u7387",
               "zh-TW": "\u706B\u529B\u5168\u958B\u64CA\u9000\u8DDD\u96E2"
+            }
+          }
+        },
+        "shion": {
+          "values": {
+            "ability1Distance%": {
+              "values": "__percent__",
+              "en-US": "Evade Distance Scalar",
+              "zh-CN": "\u673A\u52A8\u95EA\u907F\u8DDD\u79BB\u500D\u7387"
+            },
+            "ability2Kb%": {
+              "values": "__percent__",
+              "en-US": "Joyride Knockback Scalar",
+              "zh-CN": "\u7EB5\u60C5\u72C2\u98D9\u51FB\u9000\u500D\u7387"
+            },
+            "ability2Duration%": {
+              "values": "__percent__",
+              "en-US": "Joyride Duration Scalar",
+              "zh-CN": "\u7EB5\u60C5\u72C2\u98D9\u6301\u7EED\u65F6\u95F4\u500D\u7387"
+            },
+            "ability2Speed%": {
+              "values": "__percent__",
+              "en-US": "Joyride Speed Scalar",
+              "zh-CN": "\u7EB5\u60C5\u72C2\u98D9\u901F\u5EA6\u500D\u7387"
             }
           }
         },
@@ -72005,3 +72038,4 @@ if (typeof module !== "undefined") {
     overpyTemplate
   };
 }
+//# sourceMappingURL=overpy_standalone.js.map

--- a/out/overpy_standalone.js
+++ b/out/overpy_standalone.js
@@ -17224,7 +17224,8 @@ var heroKw = (
         "zh-CN": "\u7EB5\u60C5\u72C2\u98D9"
       },
       "ultimate": {
-        "en-US": "Satsuriku Spree"
+        "en-US": "Satsuriku Spree",
+        "zh-CN": "\u6740\u622E\u72C2\u5BB4"
       },
       "en-US": "Shion",
       "zh-CN": "\u6B7B\u6028"

--- a/src/data/customGameSettings.ts
+++ b/src/data/customGameSettings.ts
@@ -4345,7 +4345,8 @@ export const customGameSettingsSchema: CustomGameSettingSchema =
                         "winston",
                         "wreckingBall",
                         "ramattra",
-                        "venture"
+                        "venture",
+                        "shion"
                     ],
                     "guid": "000000007672",
                     "en-US": "Infinite Ultimate Duration",
@@ -5021,7 +5022,8 @@ export const customGameSettingsSchema: CustomGameSettingSchema =
                         "ramattra",
                         "lifeweaver",
                         "venture",
-                        "juno"
+                        "juno",
+                        "shion"
                     ],
                     "en-US": "%1$s Cooldown Time",
                     "de-DE": "%1$s – Abklingzeit",
@@ -6543,6 +6545,30 @@ export const customGameSettingsSchema: CustomGameSettingSchema =
                         "tr-TR": "Domuz Çevirme Geri İtme Skaleri",
                         "zh-CN": "鸡飞狗跳击退倍率",
                         "zh-TW": "火力全開擊退距離"
+                    }
+                }
+            },
+            "shion": {
+                "values": {
+                    "ability1Distance%": {
+                        "values": "__percent__",
+                        "en-US": "Evade Distance Scalar",
+                        "zh-CN": "机动闪避距离倍率"
+                    },
+                    "ability2Kb%": {
+                        "values": "__percent__",
+                        "en-US": "Joyride Knockback Scalar",
+                        "zh-CN": "纵情狂飙击退倍率"
+                    },
+                    "ability2Duration%": {
+                        "values": "__percent__",
+                        "en-US": "Joyride Duration Scalar",
+                        "zh-CN": "纵情狂飙持续时间倍率"
+                    },
+                    "ability2Speed%": {
+                        "values": "__percent__",
+                        "en-US": "Joyride Speed Scalar",
+                        "zh-CN": "纵情狂飙速度倍率"
                     }
                 }
             },

--- a/src/data/heroes.ts
+++ b/src/data/heroes.ts
@@ -2402,6 +2402,7 @@ export const heroKw: Record<Overwatch2Heroes, HeroData> =
         },
         "ultimate": {
             "en-US": "Satsuriku Spree",
+            "zh-CN": "杀戮狂宴",
         },
         "en-US": "Shion",
         "zh-CN": "死怨",

--- a/src/data/heroes.ts
+++ b/src/data/heroes.ts
@@ -2388,16 +2388,23 @@ export const heroKw: Record<Overwatch2Heroes, HeroData> =
         "tr-TR": "Roadhog"
     },
     "shion": {
+        "secondaryFire": {
+            "en-US": "Execution",
+            "zh-CN": "交叉枪决",
+        },
         "ability1": {
             "en-US": "Evade",
+            "zh-CN": "机动闪避",
         },
         "ability2": {
             "en-US": "Joyride",
+            "zh-CN": "纵情狂飙",
         },
         "ultimate": {
             "en-US": "Satsuriku Spree",
         },
         "en-US": "Shion",
+        "zh-CN": "死怨",
     },
     "sierra": {
         "secondaryFire": {

--- a/src/tests/decompiler/results/shionSettings.opy
+++ b/src/tests/decompiler/results/shionSettings.opy
@@ -1,0 +1,28 @@
+settings {
+    "gamemodes": {
+        "skirmish": {}
+    },
+    "heroes": {
+        "allTeams": {
+            "shion": {
+                "secondaryFireCooldown%": 113,
+                "ability1Cooldown%": 81,
+                "ability1Distance%": 110,
+                "ability2Cooldown%": 86,
+                "ability2Kb%": 119,
+                "ability2Duration%": 83,
+                "ability2Speed%": 109,
+                "enableInfiniteUlt": true
+            }
+        }
+    }
+}
+
+#Only remove the following directive if the gamemode does not use tricks such as A+0, A*0, A or "", "am" == "**", etc which would otherwise be optimized out.
+#!optimizeStrict
+
+rule "Empty Rule":
+    @Delimiter
+    
+
+

--- a/src/tests/decompiler/shionSettings.txt
+++ b/src/tests/decompiler/shionSettings.txt
@@ -1,0 +1,35 @@
+settings
+{
+    modes
+    {
+        Skirmish
+        {
+        }
+    }
+
+    heroes
+    {
+        General
+        {
+            Shion
+            {
+                Execution Cooldown Time: 113%
+                Evade Cooldown Time: 81%
+                Evade Distance Scalar: 110%
+                Joyride Cooldown Time: 86%
+                Joyride Knockback Scalar: 119%
+                Joyride Duration Scalar: 83%
+                Joyride Speed Scalar: 109%
+                Infinite Ultimate Duration: On
+            }
+        }
+    }
+}
+
+rule("Empty Rule")
+{
+    event
+    {
+        Ongoing - Global;
+    }
+}

--- a/src/tests/results/shionSettings.txt
+++ b/src/tests/results/shionSettings.txt
@@ -1,0 +1,27 @@
+settings
+{
+	modes
+	{
+		Skirmish
+		{
+		}
+	}
+	heroes
+	{
+		General
+		{
+			Shion
+			{
+				Execution Cooldown Time: 113%
+				Evade Cooldown Time: 81%
+				Evade Distance Scalar: 110%
+				Joyride Cooldown Time: 86%
+				Joyride Knockback Scalar: 119%
+				Joyride Duration Scalar: 83%
+				Joyride Speed Scalar: 109%
+				Infinite Ultimate Duration: On
+			}
+		}
+	}
+}
+

--- a/src/tests/shionSettings.opy
+++ b/src/tests/shionSettings.opy
@@ -1,0 +1,19 @@
+settings {
+    "gamemodes": {
+        "skirmish": {}
+    },
+    "heroes": {
+        "allTeams": {
+            "shion": {
+                "secondaryFireCooldown%": 113,
+                "ability1Cooldown%": 81,
+                "ability1Distance%": 110,
+                "ability2Cooldown%": 86,
+                "ability2Kb%": 119,
+                "ability2Duration%": 83,
+                "ability2Speed%": 109,
+                "enableInfiniteUlt": true
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds custom game setting for Shion, and new `ability2Speed%` schema key to support `Joyride Speed Scalar`.