### PR TITLE
Enum hover improvements

### DIFF
--- a/.github/workflows/behavior_test.yml
+++ b/.github/workflows/behavior_test.yml
@@ -37,3 +37,7 @@ jobs:
             - name: Run CLI tests
               run: |
                   pnpm run test:cli
+
+            - name: Run LSP tests
+              run: |
+                  pnpm run test:lsp

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 node_modules
 *.vsix
 /out/*

--- a/src/compiler/compiler.ts
+++ b/src/compiler/compiler.ts
@@ -68,6 +68,7 @@ export async function compile(
     writeToOutputFile: boolean;
     mainFileName: string;
     rootPath: string,
+    importedFiles: string[];
 }> {
     const t0 = performance.now();
 
@@ -323,6 +324,7 @@ rule "Disable inspector":
         writeToOutputFile: compiler.writeToOutputFile,
         mainFileName: compiler.mainFileName,
         rootPath: compiler.rootPath,
+        importedFiles: compiler.importedFiles,
     };
 }
 

--- a/src/data/opy/memberFunctions.ts
+++ b/src/data/opy/memberFunctions.ts
@@ -23,7 +23,7 @@ import { Argument, Type } from "../../types";
 export const opyMemberFuncs: Record<string, {
     description: string,
     args: Argument[] | null,
-    class: String,
+    class: string,
     return: Type
 }> = {
     "x": {

--- a/src/languageServer/completionState.ts
+++ b/src/languageServer/completionState.ts
@@ -300,6 +300,20 @@ export type SemanticTokenIndex = {
 
 const identifierPattern = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
+let cachedKeywordNames: Set<string> | null = null;
+
+function getKeywordNames(): Set<string> {
+    if (cachedKeywordNames === null) {
+        cachedKeywordNames = new Set(
+            Object.keys(opyKeywords)
+                .concat(...Object.keys(valueFuncKw).filter((x) => valueFuncKw[x].args === null))
+                .concat(...Object.keys(actionKw).filter((x) => actionKw[x].args === null))
+                .concat(...Object.keys(opyFuncs).filter((x) => opyFuncs[x].args === null)),
+        );
+    }
+    return cachedKeywordNames;
+}
+
 /**
  * Builds a categorized lookup of every known symbol name for semantic highlighting.
  * `normal` holds names usable in a normal position; `member` holds names used after a `.`.
@@ -313,11 +327,7 @@ export function getSemanticTokenIndex(uri?: string): SemanticTokenIndex {
 
     const normal = new Map<string, SemanticSymbolKind>();
     const member = new Map<string, SemanticSymbolKind>();
-    const keywordNames = new Set(Object.keys(opyKeywords)
-        .concat(...Object.keys(valueFuncKw).filter(x => valueFuncKw[x].args === null))
-        .concat(...Object.keys(actionKw).filter(x => actionKw[x].args === null))
-        .concat(...Object.keys(opyFuncs).filter(x => opyFuncs[x].args === null))
-    );
+    const keywordNames = getKeywordNames();
 
     const addNames = (
         target: Map<string, SemanticSymbolKind>,

--- a/src/languageServer/completionState.ts
+++ b/src/languageServer/completionState.ts
@@ -33,6 +33,7 @@ import { valueFuncKw } from "../data/values";
 import { DeclarationDocs, emptyDeclarationDocs } from "./declarationDocs";
 import { builtInEnumNameToAstInfo } from "../compiler/parser";
 import type { Ast } from "../utils/ast";
+import { debug } from "../utils/logging";
 import {OverPyCompiler, OverPyDecompiler} from "../godClasses";
 
 type CompletionData = {
@@ -531,7 +532,9 @@ function getUserEnumCompletionLists(
                 let description = "A user-defined enum member.";
                 try {
                     description += `\n\nValue: \`${decompiler.astToOpy(memberAst)}\``;
-                } catch (e) {}
+                } catch (error) {
+                    debug(`astToOpy failed for enum member "${memberName}": ${error instanceof Error ? error.message : String(error)}`);
+                }
 
                 const doc = enumMemberDocs?.get(memberName);
                 if (doc) {

--- a/src/languageServer/completionState.ts
+++ b/src/languageServer/completionState.ts
@@ -445,20 +445,26 @@ function buildBaseCompletionData(): void {
 }
 
 function buildCompletionState(dynamic: DynamicCompletionData): CompletionState {
-    const constantValueCompletions = {
-        ...baseConstantValueCompletions,
-        ...getUserEnumCompletionLists(dynamic.userEnums, dynamic.declarationDocs.enumMembers),
-    };
+    // An `enum Foo:` block extends Foo rather than replacing it, so user-declared members must be
+    // merged onto the built-in list (if any) for that enum, not spread over it — otherwise extending
+    // a built-in enum like Hero would drop every built-in member from completions.
+    const constantValueCompletions: Record<string, CompletionList> = { ...baseConstantValueCompletions };
+    const userEnumCompletions = getUserEnumCompletionLists(dynamic.userEnums, dynamic.declarationDocs.enumMembers);
+    for (const [enumName, userList] of Object.entries(userEnumCompletions)) {
+        constantValueCompletions[enumName] = mergeEnumCompletionLists(baseConstantValueCompletions[enumName], userList);
+    }
 
     for (const constType of ["Beam", "Effect", "DynamicEffect"]) {
-        const baseList = baseConstantValueCompletions[constType];
-        if (!baseList) {
+        const list = constantValueCompletions[constType];
+        if (!list) {
             continue;
         }
 
+        // Hide built-in values gated behind an inactive extension. User-declared members are not
+        // in `constantValues`, so the lookup misses and they are always kept.
         constantValueCompletions[constType] = {
             isIncomplete: false,
-            items: baseList.items.filter((item) => {
+            items: list.items.filter((item) => {
                 const constantEntry = constantValues[constType]?.[item.label];
                 return !constantEntry || !("extension" in constantEntry) || dynamic.activatedExtensions.includes(constantEntry.extension ?? "<INVALID>");
             }),
@@ -527,6 +533,23 @@ function makeDefaultConstantValueCompletions(): Record<string, CompletionList> {
     }
 
     return completionLists;
+}
+
+/**
+ * Combines the built-in members of an enum (if it is a built-in) with the user-declared members
+ * that extend it. Built-in members come first; a user member whose label already exists is skipped
+ * so a redeclaration does not produce a duplicate completion item.
+ */
+function mergeEnumCompletionLists(baseList: CompletionList | undefined, userList: CompletionList): CompletionList {
+    if (!baseList) {
+        return userList;
+    }
+
+    const seen = new Set(baseList.items.map((item) => item.label));
+    return {
+        isIncomplete: false,
+        items: [...baseList.items, ...userList.items.filter((item) => !seen.has(item.label))],
+    };
 }
 
 function getUserEnumCompletionLists(

--- a/src/languageServer/completionState.ts
+++ b/src/languageServer/completionState.ts
@@ -140,13 +140,13 @@ export function initializeCompletionState(): void {
     }
 
     buildBaseCompletionData();
-    refreshCompletionState();
     initialized = true;
 }
 
-export function getCompletionState(): CompletionState {
+export function getCompletionState(uri?: string): CompletionState {
     initializeCompletionState();
-    return completionState;
+    const dynamic = (uri !== undefined ? dynamicCompletionDataByUri.get(uri) : undefined) ?? dynamicCompletionData;
+    return buildCompletionState(dynamic);
 }
 
 export function updateCompletionStateFromCompileResult(
@@ -177,7 +177,6 @@ export function updateCompletionStateFromCompileResult(
     fillAstMacroCompletions(Object.values(compileResult.astMacros), declarationDocs.macros);
     fillAstConstantCompletions(Object.values(compileResult.astConstants), declarationDocs.macros);
     dynamicCompletionDataByUri.set(uri, dynamicCompletionData);
-    refreshCompletionState();
 }
 
 /** Drops a closed document's cached completion data so its symbols stop affecting highlighting. */
@@ -428,10 +427,10 @@ function buildBaseCompletionData(): void {
     );
 }
 
-function refreshCompletionState(): void {
+function buildCompletionState(dynamic: DynamicCompletionData): CompletionState {
     const constantValueCompletions = {
         ...baseConstantValueCompletions,
-        ...getUserEnumCompletionLists(dynamicCompletionData.userEnums, dynamicCompletionData.declarationDocs.enumMembers),
+        ...getUserEnumCompletionLists(dynamic.userEnums, dynamic.declarationDocs.enumMembers),
     };
 
     for (const constType of ["Beam", "Effect", "DynamicEffect"]) {
@@ -444,7 +443,7 @@ function refreshCompletionState(): void {
             isIncomplete: false,
             items: baseList.items.filter((item) => {
                 const constantEntry = constantValues[constType]?.[item.label];
-                return !constantEntry || !("extension" in constantEntry) || dynamicCompletionData.activatedExtensions.includes(constantEntry.extension ?? "<INVALID>");
+                return !constantEntry || !("extension" in constantEntry) || dynamic.activatedExtensions.includes(constantEntry.extension ?? "<INVALID>");
             }),
         };
     }
@@ -453,39 +452,41 @@ function refreshCompletionState(): void {
         ...baseFunctionData,
         ...Object.fromEntries(
             Object.keys(constantValueCompletions).map((key) => {
-                const doc = dynamicCompletionData.declarationDocs.enums.get(key);
+                const doc = dynamic.declarationDocs.enums.get(key);
                 return [key, { description: doc ? `${doc}\n\nThe \`${key}\` enum.` : `The \`${key}\` enum.` }];
             }),
         ),
-        ...dynamicCompletionData.normalAstConstants,
-        ...dynamicCompletionData.normalMacros,
-        ...dynamicCompletionData.normalAstMacros,
-        ...dynamicCompletionData.globalVariables,
-        ...dynamicCompletionData.subroutines,
+        ...dynamic.normalAstConstants,
+        ...dynamic.normalMacros,
+        ...dynamic.normalAstMacros,
+        ...dynamic.globalVariables,
+        ...dynamic.subroutines,
     };
 
     const memberItems: Record<string, CompletionData> = {
         ...baseMemberFunctionData,
-        ...dynamicCompletionData.memberMacros,
-        ...dynamicCompletionData.memberAstConstants,
-        ...dynamicCompletionData.memberAstMacros,
-        ...dynamicCompletionData.playerVariables,
+        ...dynamic.memberMacros,
+        ...dynamic.memberAstConstants,
+        ...dynamic.memberAstMacros,
+        ...dynamic.playerVariables,
     };
 
-    completionState = {
-        ...completionState,
+    return {
+        annotationCompletions: completionState.annotationCompletions,
+        preprocessingCompletions: completionState.preprocessingCompletions,
+        stringEntityCompletions: completionState.stringEntityCompletions,
         constantValueCompletions,
         defaultCompletions: makeCompletionList(defaultItems, CompletionItemKind.Function),
         functionRegistry: {
             ...baseFunctionData,
             ...baseMemberFunctionData,
             ...baseModuleFunctionData,
-            ...dynamicCompletionData.normalAstConstants,
-            ...dynamicCompletionData.normalMacros,
-            ...dynamicCompletionData.normalAstMacros,
-            ...dynamicCompletionData.memberAstConstants,
-            ...dynamicCompletionData.memberMacros,
-            ...dynamicCompletionData.memberAstMacros,
+            ...dynamic.normalAstConstants,
+            ...dynamic.normalMacros,
+            ...dynamic.normalAstMacros,
+            ...dynamic.memberAstConstants,
+            ...dynamic.memberMacros,
+            ...dynamic.memberAstMacros,
         },
         memberCompletions: makeCompletionList(memberItems, CompletionItemKind.Method),
     };

--- a/src/languageServer/completionState.ts
+++ b/src/languageServer/completionState.ts
@@ -87,7 +87,10 @@ export type CompletionState = {
     stringEntityCompletions: CompletionList;
 };
 
-//Only used for astToOpy / typeToString
+// Retained instances, not free functions: `typeToString` (compiler) recurses via `this.typeToString`
+// and throws `this.error`, and `astToOpy` (decompiler) is a prototype method bound to its instance.
+// Extracting them would require detaching that `this`-dependent machinery, so the instances are
+// load-bearing. They are used only for `typeToString` (signature labels) and `astToOpy` (enum-member values).
 const compiler = new OverPyCompiler();
 const decompiler = new OverPyDecompiler();
 
@@ -156,7 +159,7 @@ export function updateCompletionStateFromCompileResult(
 ): void {
     initializeCompletionState();
 
-    dynamicCompletionData = {
+    const next: DynamicCompletionData = {
         activatedExtensions: compileResult.activatedExtensions,
         availableExtensionPoints: compileResult.availableExtensionPoints,
         declarationDocs,
@@ -173,10 +176,12 @@ export function updateCompletionStateFromCompileResult(
         userEnums: compileResult.enumMembers,
     };
 
-    fillMacroCompletions(compileResult.macros);
-    fillAstMacroCompletions(Object.values(compileResult.astMacros), declarationDocs.macros);
-    fillAstConstantCompletions(Object.values(compileResult.astConstants), declarationDocs.macros);
-    dynamicCompletionDataByUri.set(uri, dynamicCompletionData);
+    fillMacroCompletions(next, compileResult.macros);
+    fillAstMacroCompletions(next, Object.values(compileResult.astMacros), declarationDocs.macros);
+    fillAstConstantCompletions(next, Object.values(compileResult.astConstants), declarationDocs.macros);
+
+    dynamicCompletionData = next;
+    dynamicCompletionDataByUri.set(uri, next);
 }
 
 /** Drops a closed document's cached completion data so its symbols stop affecting highlighting. */
@@ -541,9 +546,9 @@ function getUserEnumCompletionLists(
     return result;
 }
 
-function fillMacroCompletions(macros: MacroData[]): void {
-    dynamicCompletionData.normalMacros = {};
-    dynamicCompletionData.memberMacros = {};
+function fillMacroCompletions(target: DynamicCompletionData, macros: MacroData[]): void {
+    target.normalMacros = {};
+    target.memberMacros = {};
 
     for (const macro of macros) {
         const convertedMacro: CompletionData = {
@@ -557,16 +562,16 @@ function fillMacroCompletions(macros: MacroData[]): void {
         }
 
         if (macro.isMember) {
-            dynamicCompletionData.memberMacros[macroName] = convertedMacro;
+            target.memberMacros[macroName] = convertedMacro;
         } else {
-            dynamicCompletionData.normalMacros[macroName] = convertedMacro;
+            target.normalMacros[macroName] = convertedMacro;
         }
     }
 }
 
-function fillAstMacroCompletions(macros: AstMacroData[], docs: Map<string, string>): void {
-    dynamicCompletionData.normalAstMacros = {};
-    dynamicCompletionData.memberAstMacros = {};
+function fillAstMacroCompletions(target: DynamicCompletionData, macros: AstMacroData[], docs: Map<string, string>): void {
+    target.normalAstMacros = {};
+    target.memberAstMacros = {};
 
     for (const macro of macros) {
         let minIndent = Math.min(...macro.linesStr.map((line) => line.match(/^\s*/)![0].length));
@@ -591,16 +596,16 @@ function fillAstMacroCompletions(macros: AstMacroData[], docs: Map<string, strin
         }
 
         if (macro.class_) {
-            dynamicCompletionData.memberAstMacros[macroName.replace(".", "")] = convertedMacro;
+            target.memberAstMacros[macroName.replace(".", "")] = convertedMacro;
         } else {
-            dynamicCompletionData.normalAstMacros[macroName] = convertedMacro;
+            target.normalAstMacros[macroName] = convertedMacro;
         }
     }
 }
 
-function fillAstConstantCompletions(constants: AstConstantData[], docs: Map<string, string>): void {
-    dynamicCompletionData.normalAstConstants = {};
-    dynamicCompletionData.memberAstConstants = {};
+function fillAstConstantCompletions(target: DynamicCompletionData, constants: AstConstantData[], docs: Map<string, string>): void {
+    target.normalAstConstants = {};
+    target.memberAstConstants = {};
 
     for (const constant of constants) {
         const doc = docs.get((constant.class_ ?? "") + constant.name);
@@ -611,9 +616,9 @@ function fillAstConstantCompletions(constants: AstConstantData[], docs: Map<stri
         };
 
         if (constant.class_) {
-            dynamicCompletionData.memberAstConstants[constant.name.replace(".", "")] = convertedConstant;
+            target.memberAstConstants[constant.name.replace(".", "")] = convertedConstant;
         } else {
-            dynamicCompletionData.normalAstConstants[constant.name] = convertedConstant;
+            target.normalAstConstants[constant.name] = convertedConstant;
         }
     }
 }

--- a/src/languageServer/completionState.ts
+++ b/src/languageServer/completionState.ts
@@ -38,7 +38,7 @@ import {OverPyCompiler, OverPyDecompiler} from "../godClasses";
 
 type CompletionData = {
     args?: Argument[] | null;
-    class?: string | String;
+    class?: string;
     description?: string;
     extension?: string;
     hideFromAutocomplete?: boolean;
@@ -200,10 +200,11 @@ export function makeSignatureHelp(
         return undefined;
     }
 
+    let effectiveParameter = activeParameter;
     if (keywordArgument !== null) {
         const keywordIndex = func.args.findIndex((arg) => arg.name === keywordArgument);
         if (keywordIndex >= 0) {
-            activeParameter = keywordIndex;
+            effectiveParameter = keywordIndex;
         }
     }
 
@@ -257,7 +258,7 @@ export function makeSignatureHelp(
 
     return {
         activeSignature: 0,
-        activeParameter: Math.min(activeParameter, visibleArgs.length - 1),
+        activeParameter: Math.min(effectiveParameter, visibleArgs.length - 1),
         signatures: [signature],
     };
 }

--- a/src/languageServer/completions.ts
+++ b/src/languageServer/completions.ts
@@ -10,7 +10,7 @@ export function getCompletionList(
     position: Position,
     triggerCharacter?: string,
 ): CompletionList {
-    const state = getCompletionState();
+    const state = getCompletionState(document.uri);
 
     if (triggerCharacter === ".") {
         const word = getWordBeforeTrigger(document, position);

--- a/src/languageServer/declarationDocs.ts
+++ b/src/languageServer/declarationDocs.ts
@@ -1,3 +1,5 @@
+import { findLineCommentStart } from "./documentUtils";
+
 /**
  * Extracts documentation text from comments attached to user-defined declarations
  * (global/player variables, macros and enum members). A contiguous comment block
@@ -130,7 +132,7 @@ function getDocFor(lines: string[], declarationIndex: number): string | null {
 }
 
 function getTrailingComment(line: string): string | null {
-    const comment = findCommentStart(line);
+    const comment = findLineCommentStart(line);
     if (!comment || comment.directive) {
         return null;
     }
@@ -154,30 +156,3 @@ function getPrecedingComment(lines: string[], declarationIndex: number): string 
     return collected.length > 0 ? collected.join("  \n") : null;
 }
 
-function findCommentStart(line: string): { index: number; directive: boolean } | null {
-    let inString = false;
-    let quote = "";
-
-    for (let index = 0; index < line.length; index++) {
-        const character = line[index];
-
-        if (inString) {
-            if (character === quote && line[index - 1] !== "\\") {
-                inString = false;
-            }
-            continue;
-        }
-
-        if (character === "\"" || character === "'") {
-            inString = true;
-            quote = character;
-            continue;
-        }
-
-        if (character === "#") {
-            return { index, directive: line[index + 1] === "!" };
-        }
-    }
-
-    return null;
-}

--- a/src/languageServer/declarationDocs.ts
+++ b/src/languageServer/declarationDocs.ts
@@ -22,6 +22,29 @@ export function emptyDeclarationDocs(): DeclarationDocs {
     };
 }
 
+/**
+ * Folds the declarations found in `from` into `into`, mutating and returning `into`.
+ * Later merges win, so callers extract included files first and the focused document last
+ * (its unsaved buffer takes precedence over the on-disk copy of the same symbols).
+ */
+export function mergeDeclarationDocs(into: DeclarationDocs, from: DeclarationDocs): DeclarationDocs {
+    for (const key of ["variables", "subroutines", "macros", "enums"] as const) {
+        for (const [name, doc] of from[key]) {
+            into[key].set(name, doc);
+        }
+    }
+
+    for (const [enumName, members] of from.enumMembers) {
+        const target = into.enumMembers.get(enumName) ?? new Map<string, string>();
+        for (const [memberName, doc] of members) {
+            target.set(memberName, doc);
+        }
+        into.enumMembers.set(enumName, target);
+    }
+
+    return into;
+}
+
 export function extractDeclarationDocs(text: string): DeclarationDocs {
     const docs = emptyDeclarationDocs();
     const lines = text.split(/\r\n|\r|\n/);

--- a/src/languageServer/definition.ts
+++ b/src/languageServer/definition.ts
@@ -8,6 +8,13 @@ import { URI } from "vscode-uri";
 import { getIdentifierAtPosition, getPrecedingQualifiedName, rangesEqual } from "./documentUtils";
 import { getBlockEndLine, getDocumentLines, getDocumentStructure } from "./symbols";
 
+const opyFileCache = new Map<string, string[]>();
+
+/** Clears the cached `.opy` directory walk so the next workspace scan re-reads the filesystem. */
+export function invalidateOpyFileCache(): void {
+    opyFileCache.clear();
+}
+
 export type DefinitionEntry = {
     containerName?: string;
     detail: string;
@@ -171,6 +178,17 @@ export async function getWorkspaceDocuments(
 }
 
 async function findOpyFiles(root: string): Promise<string[]> {
+    const cached = opyFileCache.get(root);
+    if (cached) {
+        return cached;
+    }
+
+    const files = await walkOpyFiles(root);
+    opyFileCache.set(root, files);
+    return files;
+}
+
+async function walkOpyFiles(root: string): Promise<string[]> {
     try {
         const entries = await readdir(root, { withFileTypes: true });
         const files: string[] = [];
@@ -181,7 +199,7 @@ async function findOpyFiles(root: string): Promise<string[]> {
                 if ([".git", "node_modules", "out", "dist"].includes(entry.name)) {
                     continue;
                 }
-                files.push(...await findOpyFiles(entryPath));
+                files.push(...await walkOpyFiles(entryPath));
             } else if (entry.isFile() && entry.name.endsWith(".opy")) {
                 files.push(entryPath);
             }

--- a/src/languageServer/definition.ts
+++ b/src/languageServer/definition.ts
@@ -5,6 +5,7 @@ import { Location, Position, Range } from "vscode-languageserver/node";
 import { TextDocument } from "vscode-languageserver-textdocument";
 import { URI } from "vscode-uri";
 
+import { getIdentifierAtPosition, getPrecedingQualifiedName, rangesEqual } from "./documentUtils";
 import { getBlockEndLine, getDocumentLines, getDocumentStructure } from "./symbols";
 
 export type DefinitionEntry = {
@@ -83,13 +84,14 @@ export function getMatchingDefinition(document: TextDocument, symbol: SymbolAtPo
 
 export function getDefinitionEntries(document: TextDocument): DefinitionEntry[] {
     const lines = getDocumentLines(document);
-    const entries: DefinitionEntry[] = getDocumentStructure(document).map((item) => ({
+    const structure = getDocumentStructure(document);
+    const entries: DefinitionEntry[] = structure.map((item) => ({
         detail: item.detail,
         name: item.name,
         range: Range.create(item.line, item.nameStart, item.line, item.nameEnd),
     }));
 
-    for (const item of getDocumentStructure(document)) {
+    for (const item of structure) {
         if (item.detail !== "enum") {
             continue;
         }
@@ -116,58 +118,17 @@ export function getDefinitionEntries(document: TextDocument): DefinitionEntry[] 
 }
 
 export function getSymbolAtPosition(document: TextDocument, position: Position): SymbolAtPosition | null {
-    const text = document.getText();
-    let offset = document.offsetAt(position);
-
-    if (!isWordCharacter(text.charAt(offset)) && offset > 0 && isWordCharacter(text.charAt(offset - 1))) {
-        offset--;
-    }
-
-    if (!isWordCharacter(text.charAt(offset))) {
+    const positioned = getIdentifierAtPosition(document, position, /[A-Za-z0-9_]/, /^[A-Za-z0-9_]+$/);
+    if (!positioned) {
         return null;
     }
 
-    const startOffset = findWordStart(text, offset);
-    const endOffset = findWordEnd(text, offset);
-    const name = text.slice(startOffset, endOffset);
-    const precedingName = getPrecedingQualifiedName(text, startOffset);
-
+    const startOffset = document.offsetAt(positioned.range.start);
     return {
-        name,
-        precedingName,
-        range: Range.create(document.positionAt(startOffset), document.positionAt(endOffset)),
+        name: positioned.text,
+        precedingName: getPrecedingQualifiedName(document.getText(), startOffset),
+        range: positioned.range,
     };
-}
-
-function getPrecedingQualifiedName(text: string, wordStartOffset: number): string | undefined {
-    if (wordStartOffset < 2 || text.charAt(wordStartOffset - 1) !== ".") {
-        return undefined;
-    }
-
-    const previousWordEnd = wordStartOffset - 1;
-    const previousWordStart = findWordStart(text, previousWordEnd - 1);
-    const previousWord = text.slice(previousWordStart, previousWordEnd);
-    return previousWord.length > 0 ? previousWord : undefined;
-}
-
-function findWordStart(text: string, offset: number): number {
-    let startOffset = offset;
-    while (startOffset > 0 && isWordCharacter(text.charAt(startOffset - 1))) {
-        startOffset--;
-    }
-    return startOffset;
-}
-
-function findWordEnd(text: string, offset: number): number {
-    let endOffset = offset + 1;
-    while (endOffset < text.length && isWordCharacter(text.charAt(endOffset))) {
-        endOffset++;
-    }
-    return endOffset;
-}
-
-function isWordCharacter(character: string): boolean {
-    return /[A-Za-z0-9_]/.test(character);
 }
 
 export async function getWorkspaceDocuments(
@@ -207,15 +168,6 @@ export async function getWorkspaceDocuments(
     }
 
     return [...workspaceDocuments.values()];
-}
-
-function rangesEqual(left: Range, right: Range): boolean {
-    return (
-        left.start.line === right.start.line &&
-        left.start.character === right.start.character &&
-        left.end.line === right.end.line &&
-        left.end.character === right.end.character
-    );
 }
 
 async function findOpyFiles(root: string): Promise<string[]> {

--- a/src/languageServer/documentLifecycle.ts
+++ b/src/languageServer/documentLifecycle.ts
@@ -1,0 +1,41 @@
+/**
+ * Decides which included-document URIs should have their diagnostics blanked when a main
+ * document closes. Cross-file diagnostics are published to included URIs and tracked in
+ * `previousDiagnosticUris`, keyed by the triggering (main) URI. On close we blank the includes
+ * the closed file published to, except those that are still open in their own right or are still
+ * published-to by another main document. The closed document's own URI is excluded here; the
+ * caller blanks it unconditionally.
+ */
+export function getDiagnosticUrisToClear(
+    closedUri: string,
+    previousDiagnosticUris: Map<string, Set<string>>,
+    isOpen: (uri: string) => boolean,
+): string[] {
+    const published = previousDiagnosticUris.get(closedUri);
+    if (!published) {
+        return [];
+    }
+
+    const result: string[] = [];
+    for (const uri of published) {
+        if (uri === closedUri || isOpen(uri) || isReferencedByOther(uri, closedUri, previousDiagnosticUris)) {
+            continue;
+        }
+        result.push(uri);
+    }
+
+    return result;
+}
+
+function isReferencedByOther(
+    uri: string,
+    closedUri: string,
+    previousDiagnosticUris: Map<string, Set<string>>,
+): boolean {
+    for (const [triggerUri, uris] of previousDiagnosticUris) {
+        if (triggerUri !== closedUri && uris.has(uri)) {
+            return true;
+        }
+    }
+    return false;
+}

--- a/src/languageServer/documentUtils.ts
+++ b/src/languageServer/documentUtils.ts
@@ -116,3 +116,113 @@ export function isOffsetInStringOrComment(text: string, masked: string, offset: 
 
     return masked.charAt(index) === " ";
 }
+
+export type PositionedText = {
+    range: Range;
+    text: string;
+};
+
+/**
+ * Returns the identifier under (or immediately before) `position`. `characterPattern` defines
+ * which characters belong to a token; `tokenPattern` validates the assembled token (e.g. allowing
+ * a leading `@` or an embedded `.`). Returns null if there is no token there or it fails the
+ * token pattern. Generalizes the per-feature scanners in hover/definition.
+ */
+export function getIdentifierAtPosition(
+    document: TextDocument,
+    position: Position,
+    characterPattern: RegExp,
+    tokenPattern: RegExp,
+): PositionedText | null {
+    const text = document.getText();
+    let offset = document.offsetAt(position);
+
+    if (!characterPattern.test(text.charAt(offset)) && offset > 0 && characterPattern.test(text.charAt(offset - 1))) {
+        offset--;
+    }
+
+    if (!characterPattern.test(text.charAt(offset))) {
+        return null;
+    }
+
+    let startOffset = offset;
+    while (startOffset > 0 && characterPattern.test(text.charAt(startOffset - 1))) {
+        startOffset--;
+    }
+
+    let endOffset = offset + 1;
+    while (endOffset < text.length && characterPattern.test(text.charAt(endOffset))) {
+        endOffset++;
+    }
+
+    const tokenText = text.slice(startOffset, endOffset);
+    if (!tokenPattern.test(tokenText)) {
+        return null;
+    }
+
+    return {
+        text: tokenText,
+        range: Range.create(document.positionAt(startOffset), document.positionAt(endOffset)),
+    };
+}
+
+/**
+ * Given a string and the start offset of a word, returns the bare identifier that qualifies it
+ * (the `Foo` in `Foo.bar`), or undefined if the word is not preceded by `identifier` + `.`.
+ * Operates on any string + offset, so it serves both whole-document and single-line callers.
+ */
+export function getPrecedingQualifiedName(text: string, wordStartOffset: number): string | undefined {
+    if (wordStartOffset < 2 || text.charAt(wordStartOffset - 1) !== ".") {
+        return undefined;
+    }
+
+    let start = wordStartOffset - 2;
+    while (start >= 0 && /[A-Za-z0-9_]/.test(text.charAt(start))) {
+        start--;
+    }
+
+    const precedingName = text.slice(start + 1, wordStartOffset - 1);
+    return precedingName.length > 0 ? precedingName : undefined;
+}
+
+export function rangesEqual(left: Range, right: Range): boolean {
+    return (
+        left.start.line === right.start.line &&
+        left.start.character === right.start.character &&
+        left.end.line === right.end.line &&
+        left.end.character === right.end.character
+    );
+}
+
+/**
+ * Finds the start of a `#` line comment in a single line, skipping `#` characters inside string
+ * literals, and reports whether it is a `#!` directive. Shares the string-skipping logic with
+ * `maskStringsAndComments`; used where the comment's index and directive-ness are needed.
+ */
+export function findLineCommentStart(line: string): { index: number; directive: boolean } | null {
+    let inString = false;
+    let quote = "";
+
+    for (let index = 0; index < line.length; index++) {
+        const character = line[index];
+
+        if (inString) {
+            if (character === quote && line[index - 1] !== "\\") {
+                inString = false;
+            }
+            continue;
+        }
+
+        if (character === "\"" || character === "'") {
+            inString = true;
+            quote = character;
+            continue;
+        }
+
+        if (character === "#") {
+            return { index, directive: line[index + 1] === "!" };
+        }
+    }
+
+    return null;
+}

--- a/src/languageServer/hover.ts
+++ b/src/languageServer/hover.ts
@@ -20,12 +20,29 @@ export function getHover(document: TextDocument, position: Position): Hover | nu
 
     const qualifiedSymbol = getQualifiedSymbolAtPosition(document, position);
     if (qualifiedSymbol) {
-        const enumHover = getEnumMemberHover(qualifiedSymbol.text);
-        if (enumHover) {
-            return {
-                contents: enumHover,
-                range: qualifiedSymbol.range,
-            };
+        const dotIndex = qualifiedSymbol.text.indexOf(".");
+        const tokenStart = document.offsetAt(qualifiedSymbol.range.start);
+        const cursorInToken = document.offsetAt(position) - tokenStart;
+
+        // Hovering the part left of the `.` describes the enum itself; the part to the
+        // right (or the `.`) describes the member.
+        if (cursorInToken < dotIndex) {
+            const enumName = qualifiedSymbol.text.slice(0, dotIndex);
+            const enumNameHover = getEnumNameHover(enumName);
+            if (enumNameHover) {
+                return {
+                    contents: enumNameHover,
+                    range: Range.create(qualifiedSymbol.range.start, document.positionAt(tokenStart + dotIndex)),
+                };
+            }
+        } else {
+            const enumHover = getEnumMemberHover(qualifiedSymbol.text);
+            if (enumHover) {
+                return {
+                    contents: enumHover,
+                    range: Range.create(document.positionAt(tokenStart + dotIndex + 1), qualifiedSymbol.range.end),
+                };
+            }
         }
     }
 
@@ -96,6 +113,17 @@ function getFunctionHover(functionName: string): MarkupContent | null {
         kind: MarkupKind.Markdown,
         value: sections.join("\n\n"),
     };
+}
+
+function getEnumNameHover(enumName: string): MarkupContent | null {
+    const state = getCompletionState();
+    if (!state.constantValueCompletions[enumName]) {
+        return null;
+    }
+
+    // `defaultCompletions` carries the enum's own doc comment; fall back to the member-count
+    // summary for built-in enums that have no doc comment entry.
+    return getCompletionHover(enumName, state.defaultCompletions) ?? getEnumTypeHover(enumName);
 }
 
 function getEnumTypeHover(symbolName: string): MarkupContent | null {

--- a/src/languageServer/hover.ts
+++ b/src/languageServer/hover.ts
@@ -10,7 +10,7 @@ import {
 import { TextDocument } from "vscode-languageserver-textdocument";
 
 import { CompletionState, getCompletionState, makeFunctionSignatureLabel, makeSignatureHelp } from "./completionState";
-import { isOffsetInStringOrComment, maskStringsAndComments } from "./documentUtils";
+import { getIdentifierAtPosition, isOffsetInStringOrComment, maskStringsAndComments, PositionedText } from "./documentUtils";
 
 export function getHover(document: TextDocument, position: Position): Hover | null {
     const text = document.getText();
@@ -190,53 +190,10 @@ function normalizeSymbolName(document: TextDocument, symbol: PositionedText): st
     return symbol.text;
 }
 
-type PositionedText = {
-    range: Range;
-    text: string;
-};
-
 function getQualifiedSymbolAtPosition(document: TextDocument, position: Position): PositionedText | null {
-    return getTextAtPosition(document, position, /[A-Za-z0-9_.]/, /[A-Za-z_][A-Za-z0-9_]*\.[A-Za-z_][A-Za-z0-9_]*/);
+    return getIdentifierAtPosition(document, position, /[A-Za-z0-9_.]/, /[A-Za-z_][A-Za-z0-9_]*\.[A-Za-z_][A-Za-z0-9_]*/);
 }
 
 function getSymbolAtPosition(document: TextDocument, position: Position): PositionedText | null {
-    return getTextAtPosition(document, position, /[@A-Za-z0-9_]/, /@?[A-Za-z_][A-Za-z0-9_]*/);
-}
-
-function getTextAtPosition(
-    document: TextDocument,
-    position: Position,
-    characterPattern: RegExp,
-    tokenPattern: RegExp,
-): PositionedText | null {
-    const text = document.getText();
-    let offset = document.offsetAt(position);
-
-    if (!characterPattern.test(text.charAt(offset)) && offset > 0 && characterPattern.test(text.charAt(offset - 1))) {
-        offset--;
-    }
-
-    if (!characterPattern.test(text.charAt(offset))) {
-        return null;
-    }
-
-    let startOffset = offset;
-    while (startOffset > 0 && characterPattern.test(text.charAt(startOffset - 1))) {
-        startOffset--;
-    }
-
-    let endOffset = offset + 1;
-    while (endOffset < text.length && characterPattern.test(text.charAt(endOffset))) {
-        endOffset++;
-    }
-
-    const tokenText = text.slice(startOffset, endOffset);
-    if (!tokenPattern.test(tokenText)) {
-        return null;
-    }
-
-    return {
-        text: tokenText,
-        range: Range.create(document.positionAt(startOffset), document.positionAt(endOffset)),
-    };
+    return getIdentifierAtPosition(document, position, /[@A-Za-z0-9_]/, /@?[A-Za-z_][A-Za-z0-9_]*/);
 }

--- a/src/languageServer/hover.ts
+++ b/src/languageServer/hover.ts
@@ -9,7 +9,7 @@ import {
 } from "vscode-languageserver/node";
 import { TextDocument } from "vscode-languageserver-textdocument";
 
-import { getCompletionState, makeFunctionSignatureLabel, makeSignatureHelp } from "./completionState";
+import { CompletionState, getCompletionState, makeFunctionSignatureLabel, makeSignatureHelp } from "./completionState";
 import { isOffsetInStringOrComment, maskStringsAndComments } from "./documentUtils";
 
 export function getHover(document: TextDocument, position: Position): Hover | null {
@@ -17,6 +17,8 @@ export function getHover(document: TextDocument, position: Position): Hover | nu
     if (isOffsetInStringOrComment(text, maskStringsAndComments(text), document.offsetAt(position))) {
         return null;
     }
+
+    const state = getCompletionState(document.uri);
 
     const qualifiedSymbol = getQualifiedSymbolAtPosition(document, position);
     if (qualifiedSymbol) {
@@ -28,7 +30,7 @@ export function getHover(document: TextDocument, position: Position): Hover | nu
         // right (or the `.`) describes the member.
         if (cursorInToken < dotIndex) {
             const enumName = qualifiedSymbol.text.slice(0, dotIndex);
-            const enumNameHover = getEnumNameHover(enumName);
+            const enumNameHover = getEnumNameHover(enumName, state);
             if (enumNameHover) {
                 return {
                     contents: enumNameHover,
@@ -36,7 +38,7 @@ export function getHover(document: TextDocument, position: Position): Hover | nu
                 };
             }
         } else {
-            const enumHover = getEnumMemberHover(qualifiedSymbol.text);
+            const enumHover = getEnumMemberHover(qualifiedSymbol.text, state);
             if (enumHover) {
                 return {
                     contents: enumHover,
@@ -52,10 +54,9 @@ export function getHover(document: TextDocument, position: Position): Hover | nu
     }
 
     const normalizedName = normalizeSymbolName(document, symbol);
-    const state = getCompletionState();
     const functionData = state.functionRegistry[normalizedName];
     if (functionData) {
-        const functionHover = getFunctionHover(normalizedName);
+        const functionHover = getFunctionHover(normalizedName, state);
         if (functionHover) {
             return {
                 contents: functionHover,
@@ -70,7 +71,7 @@ export function getHover(document: TextDocument, position: Position): Hover | nu
         getCompletionHover(normalizedName, state.stringEntityCompletions) ??
         getCompletionHover(normalizedName, state.defaultCompletions) ??
         getCompletionHover(normalizedName, state.memberCompletions) ??
-        getEnumTypeHover(normalizedName);
+        getEnumTypeHover(normalizedName, state);
 
     if (!completionHover) {
         return null;
@@ -82,8 +83,8 @@ export function getHover(document: TextDocument, position: Position): Hover | nu
     };
 }
 
-function getFunctionHover(functionName: string): MarkupContent | null {
-    const functionData = getCompletionState().functionRegistry[functionName];
+function getFunctionHover(functionName: string, state: CompletionState): MarkupContent | null {
+    const functionData = state.functionRegistry[functionName];
     if (!functionData) {
         return null;
     }
@@ -115,19 +116,18 @@ function getFunctionHover(functionName: string): MarkupContent | null {
     };
 }
 
-function getEnumNameHover(enumName: string): MarkupContent | null {
-    const state = getCompletionState();
+function getEnumNameHover(enumName: string, state: CompletionState): MarkupContent | null {
     if (!state.constantValueCompletions[enumName]) {
         return null;
     }
 
     // `defaultCompletions` carries the enum's own doc comment; fall back to the member-count
     // summary for built-in enums that have no doc comment entry.
-    return getCompletionHover(enumName, state.defaultCompletions) ?? getEnumTypeHover(enumName);
+    return getCompletionHover(enumName, state.defaultCompletions) ?? getEnumTypeHover(enumName, state);
 }
 
-function getEnumTypeHover(symbolName: string): MarkupContent | null {
-    const enumCompletions = getCompletionState().constantValueCompletions[symbolName];
+function getEnumTypeHover(symbolName: string, state: CompletionState): MarkupContent | null {
+    const enumCompletions = state.constantValueCompletions[symbolName];
     if (!enumCompletions) {
         return null;
     }
@@ -138,13 +138,13 @@ function getEnumTypeHover(symbolName: string): MarkupContent | null {
     };
 }
 
-function getEnumMemberHover(qualifiedName: string): MarkupContent | null {
+function getEnumMemberHover(qualifiedName: string, state: CompletionState): MarkupContent | null {
     const [enumName, memberName] = qualifiedName.split(".");
     if (!enumName || !memberName) {
         return null;
     }
 
-    const enumCompletions = getCompletionState().constantValueCompletions[enumName];
+    const enumCompletions = state.constantValueCompletions[enumName];
     const completion = enumCompletions?.items.find((item) => item.label === memberName);
     if (!completion) {
         return null;

--- a/src/languageServer/inlayHints.ts
+++ b/src/languageServer/inlayHints.ts
@@ -23,7 +23,7 @@ export function getInlayHints(document: TextDocument, range?: Range, minParamete
         return [];
     }
 
-    const state = getCompletionState();
+    const state = getCompletionState(document.uri);
     const masked = maskStringsAndComments(document.getText());
     const hints: InlayHint[] = [];
 

--- a/src/languageServer/references.ts
+++ b/src/languageServer/references.ts
@@ -9,6 +9,7 @@ import {
     getWorkspaceDocuments,
     SymbolAtPosition,
 } from "./definition";
+import { getPrecedingQualifiedName, isOffsetInStringOrComment, maskStringsAndComments, rangesEqual } from "./documentUtils";
 import { getDocumentLines } from "./symbols";
 
 type DefinitionTarget = DefinitionEntry & {
@@ -103,12 +104,15 @@ function getReferenceTarget(
 
 function getDocumentReferences(document: TextDocument, target: DefinitionTarget): Location[] {
     const definitions = getDefinitionEntries(document);
+    const text = document.getText();
+    const masked = maskStringsAndComments(text);
     const references: Location[] = [];
 
     for (const [lineNumber, line] of getDocumentLines(document).entries()) {
         for (const occurrence of getWordOccurrences(line, target.name)) {
             const range = Range.create(lineNumber, occurrence.start, lineNumber, occurrence.end);
-            if (!isCodePosition(line, occurrence.start) || isDeclarationRange(definitions, range)) {
+            const offset = document.offsetAt({ line: lineNumber, character: occurrence.start });
+            if (isOffsetInStringOrComment(text, masked, offset) || isDeclarationRange(definitions, range)) {
                 continue;
             }
 
@@ -157,37 +161,6 @@ function getWordOccurrences(
     return occurrences;
 }
 
-function getPrecedingQualifiedName(line: string, wordStart: number): string | undefined {
-    if (wordStart < 2 || line.charAt(wordStart - 1) !== ".") {
-        return undefined;
-    }
-
-    let start = wordStart - 2;
-    while (start >= 0 && /[A-Za-z0-9_]/.test(line.charAt(start))) {
-        start--;
-    }
-
-    const precedingName = line.slice(start + 1, wordStart - 1);
-    return precedingName.length > 0 ? precedingName : undefined;
-}
-
-function isCodePosition(line: string, character: number): boolean {
-    let quote: string | undefined;
-
-    for (let index = 0; index < character; index++) {
-        const current = line.charAt(index);
-        if (quote === undefined && current === "#") {
-            return false;
-        }
-
-        if ((current === "\"" || current === "'") && (index === 0 || line.charAt(index - 1) !== "\\")) {
-            quote = quote === current ? undefined : quote ?? current;
-        }
-    }
-
-    return quote === undefined;
-}
-
 function uniqueLocations(locations: Location[]): Location[] {
     const seen = new Set<string>();
     const result: Location[] = [];
@@ -205,13 +178,4 @@ function uniqueLocations(locations: Location[]): Location[] {
 
 function locationsEqual(left: Location, right: Location): boolean {
     return left.uri === right.uri && rangesEqual(left.range, right.range);
-}
-
-function rangesEqual(left: Range, right: Range): boolean {
-    return (
-        left.start.line === right.start.line &&
-        left.start.character === right.start.character &&
-        left.end.line === right.end.line &&
-        left.end.character === right.end.character
-    );
 }

--- a/src/languageServer/semanticTokens.ts
+++ b/src/languageServer/semanticTokens.ts
@@ -9,6 +9,10 @@ export const semanticTokenTypes = [
     "method",
     "macro",
     "variable",
+    // `constant.character.escape` is deliberately overloaded to color enum *type* names. The name is
+    // not literal here — it is reused because most themes map it to a distinct, readable color that
+    // suits enums. Do NOT rename it to something like `enum`: that would break the theme-color mapping
+    // editors already apply, regressing enum highlighting. `enumMember` (below) colors enum members.
     "constant.character.escape", //Enums
     "enumMember",
     "regexp", //@Annotations
@@ -56,7 +60,7 @@ function emitLineTokens(
         const nameStart = matchIndex + prefix.length;
 
         if (prefix === "@") {
-            //push(matchIndex, prefix.length + name.length, "regexp");
+            push(matchIndex, prefix.length + name.length, "regexp");
         } else if (prefix === ".") {
             const ownerName: string | null = previousEnd === matchIndex ? previousName : null;
             if (ownerName && index.enumTypes.has(ownerName) && index.enumMembers.get(ownerName)?.has(name)) {

--- a/src/languageServer/server.ts
+++ b/src/languageServer/server.ts
@@ -17,7 +17,7 @@ import { getCodeActions } from "./codeActions";
 import { getColorPresentations, getDocumentColors } from "./colors";
 import { getCompletionList } from "./completions";
 import { clearDocumentCompletionData } from "./completionState";
-import { getWorkspaceDefinition } from "./definition";
+import { getWorkspaceDefinition, invalidateOpyFileCache } from "./definition";
 import { getDiagnosticUrisToClear } from "./documentLifecycle";
 import { getDocumentLinks } from "./documentLinks";
 import { getFoldingRanges } from "./foldingRanges";
@@ -126,6 +126,12 @@ connection.onDidChangeConfiguration((change) => {
     for (const document of documents.all()) {
         scheduleValidate(document);
     }
+});
+
+connection.onDidChangeWatchedFiles(() => {
+    // The client watches `**/*.opy`; any create/delete/change can change the workspace file set,
+    // so drop the cached directory walk and let the next definition/reference scan rebuild it.
+    invalidateOpyFileCache();
 });
 
 documents.onDidOpen((event) => scheduleValidate(event.document));

--- a/src/languageServer/server.ts
+++ b/src/languageServer/server.ts
@@ -18,6 +18,7 @@ import { getColorPresentations, getDocumentColors } from "./colors";
 import { getCompletionList } from "./completions";
 import { clearDocumentCompletionData } from "./completionState";
 import { getWorkspaceDefinition } from "./definition";
+import { getDiagnosticUrisToClear } from "./documentLifecycle";
 import { getDocumentLinks } from "./documentLinks";
 import { getFoldingRanges } from "./foldingRanges";
 import { getHover } from "./hover";
@@ -131,11 +132,22 @@ documents.onDidOpen((event) => scheduleValidate(event.document));
 documents.onDidChangeContent((event) => scheduleValidate(event.document));
 documents.onDidSave((event) => scheduleValidate(event.document));
 documents.onDidClose((event) => {
-    clearPendingValidation(event.document.uri);
-    clearDocumentCompletionData(event.document.uri);
-    documentSettings.delete(event.document.uri);
-    previousDiagnosticUris.delete(event.document.uri);
-    connection.sendDiagnostics({ uri: event.document.uri, diagnostics: [] });
+    const closedUri = event.document.uri;
+    clearPendingValidation(closedUri);
+    clearDocumentCompletionData(closedUri);
+    documentSettings.delete(closedUri);
+
+    const urisToClear = getDiagnosticUrisToClear(
+        closedUri,
+        previousDiagnosticUris,
+        (uri) => documents.get(uri) !== undefined,
+    );
+    previousDiagnosticUris.delete(closedUri);
+
+    for (const uri of urisToClear) {
+        connection.sendDiagnostics({ uri, diagnostics: [] });
+    }
+    connection.sendDiagnostics({ uri: closedUri, diagnostics: [] });
 });
 
 connection.onCompletion((params): CompletionList | null => {

--- a/src/languageServer/server.ts
+++ b/src/languageServer/server.ts
@@ -63,6 +63,7 @@ const documents = new TextDocuments(TextDocument);
 const pendingValidations = new Map<string, NodeJS.Timeout>();
 const documentSettings = new Map<string, Thenable<OverpySettings>>();
 const previousDiagnosticUris = new Map<string, Set<string>>();
+const VALIDATION_DEBOUNCE_MS = 400;
 
 let hasConfigurationCapability = false;
 let hasSemanticTokensRefreshSupport = false;
@@ -251,7 +252,7 @@ connection.onCodeAction((params) => {
     return getCodeActions(document, params.context.diagnostics);
 });
 
-connection.onDefinition(async (params) => {
+connection.onDefinition((params) => {
     const document = documents.get(params.textDocument.uri);
     if (!document) {
         return null;
@@ -260,7 +261,7 @@ connection.onDefinition(async (params) => {
     return getWorkspaceDefinition(document, params.position, workspaceRoots, documents.all());
 });
 
-connection.onReferences(async (params) => {
+connection.onReferences((params) => {
     const document = documents.get(params.textDocument.uri);
     if (!document) {
         return [];
@@ -275,7 +276,7 @@ connection.onReferences(async (params) => {
     );
 });
 
-connection.onPrepareRename(async (params) => {
+connection.onPrepareRename((params) => {
     const document = documents.get(params.textDocument.uri);
     if (!document) {
         return null;
@@ -284,7 +285,7 @@ connection.onPrepareRename(async (params) => {
     return getPrepareRename(document, params.position, workspaceRoots, documents.all());
 });
 
-connection.onRenameRequest(async (params) => {
+connection.onRenameRequest((params) => {
     const document = documents.get(params.textDocument.uri);
     if (!document) {
         return null;
@@ -307,7 +308,7 @@ function scheduleValidate(document: TextDocument): void {
         setTimeout(() => {
             pendingValidations.delete(document.uri);
             void validateAndPublish(document);
-        }, 400),
+        }, VALIDATION_DEBOUNCE_MS),
     );
 }
 

--- a/src/languageServer/signatureHelp.ts
+++ b/src/languageServer/signatureHelp.ts
@@ -18,7 +18,7 @@ export function getSignatureHelp(
         return undefined;
     }
 
-    const functionData = getCompletionState().functionRegistry[signatureContext.functionName];
+    const functionData = getCompletionState(document.uri).functionRegistry[signatureContext.functionName];
     if (!functionData) {
         return undefined;
     }

--- a/src/languageServer/symbols.ts
+++ b/src/languageServer/symbols.ts
@@ -75,8 +75,9 @@ function parseRule(line: string): Omit<StructuralItem, "line"> | null {
         return null;
     }
 
-    const nameStart = line.indexOf("\"") + 1;
-    const name = match[2] || "<empty>";
+    const quoteChar = match[3];
+    const nameStart = line.indexOf(quoteChar) + 1;
+    const name = match[4] || "<empty>";
     return {
         detail: "rule",
         indent: getIndent(match[1] ?? ""),

--- a/src/languageServer/validation.ts
+++ b/src/languageServer/validation.ts
@@ -6,7 +6,7 @@ import { URI } from "vscode-uri";
 
 import { compile } from "../compiler/compiler";
 import type { OWLanguage } from "../types";
-import { OpyError as OverpyError } from "../utils/logging";
+import { OpyError } from "../utils/logging";
 import { groupDiagnosticsByUri, getDocumentFileInfo } from "./diagnostics";
 import { updateCompletionStateFromCompileResult } from "./completionState";
 import { DeclarationDocs, emptyDeclarationDocs, extractDeclarationDocs, mergeDeclarationDocs } from "./declarationDocs";
@@ -33,7 +33,7 @@ export async function validateTextDocument(
             diagnosticsByUri: groupDiagnosticsByUri(compileResult.encounteredWarnings, document),
         };
     } catch (error) {
-        if (error instanceof OverpyError) {
+        if (error instanceof OpyError) {
             return {
                 diagnosticsByUri: groupDiagnosticsByUri([error], document),
             };

--- a/src/languageServer/validation.ts
+++ b/src/languageServer/validation.ts
@@ -1,12 +1,15 @@
+import { readFileSync } from "node:fs";
+
 import { Diagnostic } from "vscode-languageserver/node";
 import { TextDocument } from "vscode-languageserver-textdocument";
+import { URI } from "vscode-uri";
 
 import { compile } from "../compiler/compiler";
 import type { OWLanguage } from "../types";
 import { OpyError as OverpyError } from "../utils/logging";
 import { groupDiagnosticsByUri, getDocumentFileInfo } from "./diagnostics";
 import { updateCompletionStateFromCompileResult } from "./completionState";
-import { extractDeclarationDocs } from "./declarationDocs";
+import { DeclarationDocs, emptyDeclarationDocs, extractDeclarationDocs, mergeDeclarationDocs } from "./declarationDocs";
 import { initializeLanguageServerRuntime } from "./runtime";
 
 export type ValidationResult = {
@@ -23,7 +26,8 @@ export async function validateTextDocument(
 
     try {
         const compileResult = await compile(document.getText(), workshopLanguage, rootPath, mainFileName);
-        updateCompletionStateFromCompileResult(document.uri, compileResult, extractDeclarationDocs(document.getText()));
+        const declarationDocs = collectDeclarationDocs(document, compileResult.importedFiles);
+        updateCompletionStateFromCompileResult(document.uri, compileResult, declarationDocs);
 
         return {
             diagnosticsByUri: groupDiagnosticsByUri(compileResult.encounteredWarnings, document),
@@ -37,4 +41,30 @@ export async function validateTextDocument(
 
         throw error;
     }
+}
+
+/**
+ * Doc comments can live in a different file than the symbol's usage (enums, macros, variables and
+ * subroutines are routinely defined in a module and `#!include`d). The compiler reads every such
+ * file while resolving includes and records their paths in `importedFiles`, so we re-extract docs
+ * from each of them and merge. The focused document is read from its (possibly unsaved) open buffer
+ * and merged last so it overrides the on-disk copy of the same symbols.
+ */
+function collectDeclarationDocs(document: TextDocument, importedFiles: string[]): DeclarationDocs {
+    const docs = emptyDeclarationDocs();
+    const currentPath = URI.parse(document.uri).fsPath.replaceAll("\\", "/");
+
+    for (const importedFile of importedFiles) {
+        const normalized = importedFile.replaceAll("\\", "/");
+        if (!normalized.endsWith(".opy") || normalized === currentPath) {
+            continue;
+        }
+        try {
+            mergeDeclarationDocs(docs, extractDeclarationDocs(readFileSync(importedFile, "utf-8")));
+        } catch {
+            // An include that can't be read on disk simply contributes no docs.
+        }
+    }
+
+    return mergeDeclarationDocs(docs, extractDeclarationDocs(document.getText()));
 }

--- a/src/test/languageServer.test.ts
+++ b/src/test/languageServer.test.ts
@@ -24,6 +24,7 @@ import { extractDeclarationDocs } from "../languageServer/declarationDocs";
 import { getColorPresentations, getDocumentColors } from "../languageServer/colors";
 import { getDefinition, getWorkspaceDefinition } from "../languageServer/definition";
 import { toLspDiagnostic } from "../languageServer/diagnostics";
+import { getDiagnosticUrisToClear } from "../languageServer/documentLifecycle";
 import { getDocumentLinks } from "../languageServer/documentLinks";
 import { getFoldingRanges } from "../languageServer/foldingRanges";
 import { getHover } from "../languageServer/hover";
@@ -887,6 +888,41 @@ async function main(): Promise<void> {
     // Built-ins are shared, so they still resolve regardless of which document is focused.
     const bleedBuiltinHover = getHover(bleedDocA, { line: 5, character: "    scoreA = scaleA(sco".length });
     assert.ok(bleedBuiltinHover, "built-in/user symbols in A still hover after B validated");
+
+    // §4.1 — closing a main file must clear diagnostics it published to its includes,
+    // but never blank an include that is open or still published-to by another main file.
+    const mainUri = "file:///tmp/close-main.opy";
+    const includeUri = "file:///tmp/close-include.opy";
+    const otherMainUri = "file:///tmp/close-other-main.opy";
+
+    // (1) Lone main closes -> its include is cleared (its own URI is excluded; the caller clears it).
+    const loneMap = new Map<string, Set<string>>([[mainUri, new Set([mainUri, includeUri])]]);
+    assert.deepEqual(
+        getDiagnosticUrisToClear(mainUri, loneMap, () => false),
+        [includeUri],
+    );
+
+    // (2) Two mains share an include; closing one retains the shared include.
+    const sharedMap = new Map<string, Set<string>>([
+        [mainUri, new Set([mainUri, includeUri])],
+        [otherMainUri, new Set([otherMainUri, includeUri])],
+    ]);
+    assert.deepEqual(
+        getDiagnosticUrisToClear(mainUri, sharedMap, () => false),
+        [],
+    );
+
+    // (3) The include is itself an open document -> never blanked.
+    assert.deepEqual(
+        getDiagnosticUrisToClear(mainUri, loneMap, (uri) => uri === includeUri),
+        [],
+    );
+
+    // (4) No recorded entry -> nothing to clear.
+    assert.deepEqual(
+        getDiagnosticUrisToClear("file:///tmp/never-validated.opy", loneMap, () => false),
+        [],
+    );
 
     console.log("LSP adapter tests passed");
 }

--- a/src/test/languageServer.test.ts
+++ b/src/test/languageServer.test.ts
@@ -954,6 +954,19 @@ async function main(): Promise<void> {
     assert.ok(rangesEqual(Range.create(0, 0, 0, 4), Range.create(0, 0, 0, 4)));
     assert.ok(!rangesEqual(Range.create(0, 0, 0, 4), Range.create(0, 0, 0, 5)));
 
+    // §3.1 — `@`-annotations are highlighted with the `regexp` token type.
+    const annotationTokenDocument = TextDocument.create(
+        "file:///tmp/annotation-token.opy",
+        "overpy",
+        1,
+        "rule \"r\":\n    @Event global",
+    );
+    const annotationTokens = decodeSemanticTokens(getSemanticTokens(annotationTokenDocument).data);
+    assert.ok(
+        annotationTokens.some((token) => token.type === "regexp" && token.line === 1),
+        "the @Event annotation should emit a regexp semantic token",
+    );
+
     console.log("LSP adapter tests passed");
 }
 

--- a/src/test/languageServer.test.ts
+++ b/src/test/languageServer.test.ts
@@ -832,8 +832,8 @@ async function main(): Promise<void> {
     assert.ok(respawnHover);
     assert.doesNotMatch(getHoverText(respawnHover), /unrelated header/, "a blank line should break the comment block");
 
-    // §1.1 — cross-document state bleed: validating B must not erase A's symbols for
-    // hover/completion/signature/inlay. The per-URI snapshot, not the global, must win.
+    // Validating B must not erase A's symbols for hover/completion/signature/inlay:
+    // each consumer must read A's per-URI snapshot, not the most-recently-validated global.
     const bleedDocA = TextDocument.create(
         "file:///tmp/bleedA.opy",
         "overpy",
@@ -890,7 +890,7 @@ async function main(): Promise<void> {
     const bleedBuiltinHover = getHover(bleedDocA, { line: 5, character: "    scoreA = scaleA(sco".length });
     assert.ok(bleedBuiltinHover, "built-in/user symbols in A still hover after B validated");
 
-    // §4.1 — closing a main file must clear diagnostics it published to its includes,
+    // Closing a main file must clear diagnostics it published to its includes,
     // but never blank an include that is open or still published-to by another main file.
     const mainUri = "file:///tmp/close-main.opy";
     const includeUri = "file:///tmp/close-include.opy";
@@ -925,7 +925,7 @@ async function main(): Promise<void> {
         [],
     );
 
-    // Cluster B — shared identifier-at-position primitive characterization.
+    // Shared identifier-at-position primitive characterization.
     const primitiveDoc = TextDocument.create("file:///tmp/primitive.opy", "overpy", 1, "Hero.ANA = wait");
     const wordPattern = { char: /[A-Za-z0-9_]/, token: /^[A-Za-z0-9_]+$/ };
 
@@ -954,7 +954,7 @@ async function main(): Promise<void> {
     assert.ok(rangesEqual(Range.create(0, 0, 0, 4), Range.create(0, 0, 0, 4)));
     assert.ok(!rangesEqual(Range.create(0, 0, 0, 4), Range.create(0, 0, 0, 5)));
 
-    // §3.1 — `@`-annotations are highlighted with the `regexp` token type.
+    // `@`-annotations are highlighted with the `regexp` token type.
     const annotationTokenDocument = TextDocument.create(
         "file:///tmp/annotation-token.opy",
         "overpy",
@@ -967,7 +967,7 @@ async function main(): Promise<void> {
         "the @Event annotation should emit a regexp semantic token",
     );
 
-    // §6 — the .opy file index is cached per root and only refreshed on explicit invalidation.
+    // The .opy file index is cached per root and only refreshed on explicit invalidation.
     const cacheRoot = await mkdtemp(path.join(tmpdir(), "opy-cache-"));
     try {
         await writeFile(path.join(cacheRoot, "first.opy"), "globalvar a\n");

--- a/src/test/languageServer.test.ts
+++ b/src/test/languageServer.test.ts
@@ -22,7 +22,7 @@ import { getCodeActions } from "../languageServer/codeActions";
 import { getCompletionList } from "../languageServer/completions";
 import { extractDeclarationDocs } from "../languageServer/declarationDocs";
 import { getColorPresentations, getDocumentColors } from "../languageServer/colors";
-import { getDefinition, getWorkspaceDefinition } from "../languageServer/definition";
+import { getDefinition, getWorkspaceDefinition, getWorkspaceDocuments, invalidateOpyFileCache } from "../languageServer/definition";
 import { toLspDiagnostic } from "../languageServer/diagnostics";
 import { getDiagnosticUrisToClear } from "../languageServer/documentLifecycle";
 import { getDocumentLinks } from "../languageServer/documentLinks";
@@ -966,6 +966,30 @@ async function main(): Promise<void> {
         annotationTokens.some((token) => token.type === "regexp" && token.line === 1),
         "the @Event annotation should emit a regexp semantic token",
     );
+
+    // §6 — the .opy file index is cached per root and only refreshed on explicit invalidation.
+    const cacheRoot = await mkdtemp(path.join(tmpdir(), "opy-cache-"));
+    try {
+        await writeFile(path.join(cacheRoot, "first.opy"), "globalvar a\n");
+        const probe = TextDocument.create(URI.file(path.join(cacheRoot, "probe.opy")).toString(), "overpy", 1, "globalvar p\n");
+
+        invalidateOpyFileCache();
+        const firstScan = await getWorkspaceDocuments(probe, [cacheRoot], []);
+        assert.ok(firstScan.some((doc) => doc.uri.endsWith("first.opy")));
+
+        // Adding a file without invalidating must not appear (stale cache is intended).
+        await writeFile(path.join(cacheRoot, "second.opy"), "globalvar b\n");
+        const cachedScan = await getWorkspaceDocuments(probe, [cacheRoot], []);
+        assert.ok(!cachedScan.some((doc) => doc.uri.endsWith("second.opy")), "new file is hidden until cache invalidated");
+
+        // After invalidation the new file is discovered.
+        invalidateOpyFileCache();
+        const freshScan = await getWorkspaceDocuments(probe, [cacheRoot], []);
+        assert.ok(freshScan.some((doc) => doc.uri.endsWith("second.opy")), "invalidation refreshes the index");
+    } finally {
+        await rm(cacheRoot, { force: true, recursive: true });
+        invalidateOpyFileCache();
+    }
 
     console.log("LSP adapter tests passed");
 }

--- a/src/test/languageServer.test.ts
+++ b/src/test/languageServer.test.ts
@@ -830,6 +830,64 @@ async function main(): Promise<void> {
     assert.ok(respawnHover);
     assert.doesNotMatch(getHoverText(respawnHover), /unrelated header/, "a blank line should break the comment block");
 
+    // §1.1 — cross-document state bleed: validating B must not erase A's symbols for
+    // hover/completion/signature/inlay. The per-URI snapshot, not the global, must win.
+    const bleedDocA = TextDocument.create(
+        "file:///tmp/bleedA.opy",
+        "overpy",
+        1,
+        [
+            "macro scaleA(value):",
+            "    value * 2",
+            "globalvar scoreA",
+            "rule \"rA\":",
+            "    @Event global",
+            "    scoreA = scaleA(scoreA)",
+        ].join("\n"),
+    );
+    const bleedDocB = TextDocument.create(
+        "file:///tmp/bleedB.opy",
+        "overpy",
+        1,
+        [
+            "macro scaleB(value):",
+            "    value * 3",
+            "globalvar scoreB",
+            "rule \"rB\":",
+            "    @Event global",
+            "    scoreB = scaleB(scoreB)",
+        ].join("\n"),
+    );
+    await validateTextDocument(bleedDocA, "en-US");
+    await validateTextDocument(bleedDocB, "en-US"); // global now reflects B
+
+    const bleedHover = getHover(bleedDocA, { line: 5, character: "    scoreA = sca".length });
+    assert.ok(bleedHover, "hover on A's macro must resolve from A's snapshot");
+    assert.match(getHoverText(bleedHover), /scaleA/);
+
+    const bleedCompletions = getCompletionList(bleedDocA, { line: 3, character: 0 });
+    assert.ok(
+        bleedCompletions.items.some((item) => item.label === "scaleA"),
+        "A's default completions must contain A's macro",
+    );
+    assert.ok(
+        !bleedCompletions.items.some((item) => item.label === "scaleB"),
+        "A's default completions must not contain B's macro",
+    );
+
+    const bleedSignature = getSignatureHelp(bleedDocA, { line: 5, character: "    scoreA = scaleA(".length }, "(");
+    assert.ok(bleedSignature, "signature help on A's macro must resolve from A's snapshot");
+
+    const bleedInlay = getInlayHints(bleedDocA);
+    assert.ok(
+        bleedInlay.some((hint) => hint.label === "value:"),
+        "inlay hints on A's call must resolve A's parameter name",
+    );
+
+    // Built-ins are shared, so they still resolve regardless of which document is focused.
+    const bleedBuiltinHover = getHover(bleedDocA, { line: 5, character: "    scoreA = scaleA(sco".length });
+    assert.ok(bleedBuiltinHover, "built-in/user symbols in A still hover after B validated");
+
     console.log("LSP adapter tests passed");
 }
 

--- a/src/test/languageServer.test.ts
+++ b/src/test/languageServer.test.ts
@@ -213,7 +213,7 @@ async function main(): Promise<void> {
     );
     const semanticTokens = decodeSemanticTokens(getSemanticTokens(semanticDocument).data);
     assert.ok(semanticTokens.some((token) => token.line === 0 && token.character === 0 && token.length === 4 && token.type === "function"));
-    assert.ok(semanticTokens.some((token) => token.line === 1 && token.character === 0 && token.length === 4 && token.type === "enum"));
+    assert.ok(semanticTokens.some((token) => token.line === 1 && token.character === 0 && token.length === 4 && token.type === "constant.character.escape"));
     assert.ok(semanticTokens.some((token) => token.line === 1 && token.character === 5 && token.length === 3 && token.type === "enumMember"));
     assert.ok(semanticTokens.some((token) => token.line === 2 && token.character === 12 && token.type === "method"));
     assert.ok(!semanticTokens.some((token) => token.line === 0 && token.character > 7), "tokens inside comments should be ignored");

--- a/src/test/languageServer.test.ts
+++ b/src/test/languageServer.test.ts
@@ -85,7 +85,8 @@ async function main(): Promise<void> {
             "# Charge toward the ultimate",
             "playervar ultCharge",
             "def resetScore(): # Reset the score to zero",
-            "enum GameStatus:",
+            "# Tracks the match lifecycle",
+            "enum GameStatus: # high level summary",
             "    # Waiting for players to join",
             "    SETUP = 0",
             "    PLAYING = 1 # Match is live",
@@ -95,6 +96,8 @@ async function main(): Promise<void> {
     assert.equal(declarationDocs.variables.get("score"), "The team's score");
     assert.equal(declarationDocs.variables.get("ultCharge"), "Charge toward the ultimate");
     assert.equal(declarationDocs.subroutines.get("resetScore"), "Reset the score to zero");
+    // The enum itself merges its above-block comment with the inline comment on the declaration.
+    assert.equal(declarationDocs.enums.get("GameStatus"), "Tracks the match lifecycle  \nhigh level summary");
     assert.equal(declarationDocs.enumMembers.get("GameStatus")?.get("SETUP"), "Waiting for players to join");
     assert.equal(declarationDocs.enumMembers.get("GameStatus")?.get("PLAYING"), "Match is live");
 
@@ -646,6 +649,45 @@ async function main(): Promise<void> {
                 ],
             ],
         );
+
+        // Doc comments live in an #!included file but must surface on hover at the usage site,
+        // and the enum-name vs member side of the dot must resolve to different hovers.
+        const docsSharedPath = path.join(workspaceRoot, "docs-shared.opy");
+        await writeFile(
+            docsSharedPath,
+            [
+                "# The current game phase",
+                "enum DocState: # phase tracker",
+                "    # Waiting for players",
+                "    LOBBY = 0 # initial value",
+                "    LIVE = 1",
+            ].join("\n"),
+        );
+        const docsMainPath = path.join(workspaceRoot, "docs-main.opy");
+        const docsMainText = [
+            "#!include \"docs-shared.opy\"",
+            "rule \"r\":",
+            "    @Event global",
+            "    wait(DocState.LOBBY, Wait.IGNORE_CONDITION)",
+        ].join("\n");
+        await writeFile(docsMainPath, docsMainText);
+        const docsMainDocument = TextDocument.create(URI.file(docsMainPath).toString(), "overpy", 1, docsMainText);
+        await validateTextDocument(docsMainDocument, "en-US");
+
+        // Right of the dot -> member hover (merged above-block + inline comment from the included file).
+        const includedMemberHover = getHover(docsMainDocument, { line: 3, character: "    wait(DocState.LO".length });
+        assert.ok(includedMemberHover);
+        assert.match(getHoverText(includedMemberHover), /\*\*DocState\.LOBBY\*\*/);
+        assert.match(getHoverText(includedMemberHover), /Waiting for players/);
+        assert.match(getHoverText(includedMemberHover), /initial value/);
+
+        // Left of the dot -> enum-level hover (its own doc comment), never the member doc.
+        const includedEnumHover = getHover(docsMainDocument, { line: 3, character: "    wait(DocS".length });
+        assert.ok(includedEnumHover);
+        assert.match(getHoverText(includedEnumHover), /\*\*DocState\*\*/);
+        assert.match(getHoverText(includedEnumHover), /The current game phase/);
+        assert.match(getHoverText(includedEnumHover), /phase tracker/);
+        assert.doesNotMatch(getHoverText(includedEnumHover), /Waiting for players/);
     } finally {
         await rm(workspaceRoot, { force: true, recursive: true });
     }

--- a/src/test/languageServer.test.ts
+++ b/src/test/languageServer.test.ts
@@ -26,6 +26,7 @@ import { getDefinition, getWorkspaceDefinition } from "../languageServer/definit
 import { toLspDiagnostic } from "../languageServer/diagnostics";
 import { getDiagnosticUrisToClear } from "../languageServer/documentLifecycle";
 import { getDocumentLinks } from "../languageServer/documentLinks";
+import { getIdentifierAtPosition, getPrecedingQualifiedName, rangesEqual } from "../languageServer/documentUtils";
 import { getFoldingRanges } from "../languageServer/foldingRanges";
 import { getHover } from "../languageServer/hover";
 import { getInlayHints } from "../languageServer/inlayHints";
@@ -923,6 +924,35 @@ async function main(): Promise<void> {
         getDiagnosticUrisToClear("file:///tmp/never-validated.opy", loneMap, () => false),
         [],
     );
+
+    // Cluster B — shared identifier-at-position primitive characterization.
+    const primitiveDoc = TextDocument.create("file:///tmp/primitive.opy", "overpy", 1, "Hero.ANA = wait");
+    const wordPattern = { char: /[A-Za-z0-9_]/, token: /^[A-Za-z0-9_]+$/ };
+
+    // Cursor on the first token of a qualified name returns just that token.
+    const heroToken = getIdentifierAtPosition(primitiveDoc, { line: 0, character: 2 }, wordPattern.char, wordPattern.token);
+    assert.equal(heroToken?.text, "Hero");
+    assert.deepEqual(heroToken?.range, Range.create(0, 0, 0, 4));
+
+    // Cursor just past a token's end (on the boundary) still resolves the token.
+    const boundaryToken = getIdentifierAtPosition(primitiveDoc, { line: 0, character: 4 }, wordPattern.char, wordPattern.token);
+    assert.equal(boundaryToken?.text, "Hero");
+
+    // Cursor on whitespace with no adjacent word char returns null.
+    const noToken = getIdentifierAtPosition(
+        TextDocument.create("file:///tmp/none.opy", "overpy", 1, "   "),
+        { line: 0, character: 1 },
+        wordPattern.char,
+        wordPattern.token,
+    );
+    assert.equal(noToken, null);
+
+    // Preceding qualified name: the member after a dot reports its owner.
+    assert.equal(getPrecedingQualifiedName("Hero.ANA", "Hero.".length), "Hero");
+    assert.equal(getPrecedingQualifiedName("ANA", 0), undefined);
+
+    assert.ok(rangesEqual(Range.create(0, 0, 0, 4), Range.create(0, 0, 0, 4)));
+    assert.ok(!rangesEqual(Range.create(0, 0, 0, 4), Range.create(0, 0, 0, 5)));
 
     console.log("LSP adapter tests passed");
 }

--- a/src/test/languageServer.test.ts
+++ b/src/test/languageServer.test.ts
@@ -804,6 +804,28 @@ async function main(): Promise<void> {
     assert.ok(playingItem);
     assert.match(getDocumentationValue(playingItem), /Match is live/);
 
+    // Extending a built-in enum adds members; it must not erase the built-in ones.
+    const extendedEnumDocument = TextDocument.create(
+        "file:///tmp/extend-hero.opy",
+        "overpy",
+        1,
+        ["enum Hero:", "    cat = Hero.JETPACK_CAT"].join("\n"),
+    );
+    await validateTextDocument(extendedEnumDocument, "en-US");
+    const extendedHeroCompletions = getCompletionList(
+        TextDocument.create("file:///tmp/hero-use.opy", "overpy", 1, "Hero."),
+        { line: 0, character: "Hero.".length },
+        ".",
+    );
+    assert.ok(
+        extendedHeroCompletions.items.some((item) => item.label === "cat"),
+        "extended enum member should be present",
+    );
+    assert.ok(
+        extendedHeroCompletions.items.some((item) => item.label === "ANA"),
+        "built-in enum members should survive extension",
+    );
+
     const macroDocsDocument = TextDocument.create(
         "file:///tmp/macros.opy",
         "overpy",


### PR DESCRIPTION
Splits enum hover so the name and member resolve independently, and surfaces doc comments defined in `#!include`d files for cold starts (non compiled).

I also added the LSP tests to CI.