### PR TITLE
Fix Autocomplete Regression on Unsaved Files

### DIFF
--- a/src/compiler/astParser.ts
+++ b/src/compiler/astParser.ts
@@ -362,7 +362,8 @@ OverPyCompiler.prototype.parseAstRules = function(rules: Ast[]) {
         } else if (rule.name === "pass") {
             continue;
         } else {
-            this.error("Unexpected function '" + rule.name + "' outside a rule");
+            const usageFrame = rule.fileStack.find((frame) => frame.staticMember);
+            this.error("Unexpected function '" + rule.name + "' outside a rule", usageFrame ? [usageFrame] : rule.fileStack);
         }
 
         this.currentRuleName = rule.ruleAttributes.name;

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -922,7 +922,9 @@ OverPyCompiler.prototype.parse = function(content: Token[], kwargs: Record<strin
 
         //Check for constant
         if (name in this.astConstants) {
-            return this.astConstants[name].value.clone();
+            let result = this.astConstants[name].value.clone();
+            result.fileStack = this.getFileStackRange(content);
+            return result;
         }
 
 
@@ -1222,7 +1224,9 @@ OverPyCompiler.prototype.parseMember = function(object: Token[], member: Token[]
             //Check for member of a user-declared enum
             //Do not throw an error if the name is not in the enum, as it can be in a built-in enum
             if (object[0].text in this.enumMembers && name in this.enumMembers[object[0].text]) {
-                return this.enumMembers[object[0].text][name].clone();
+                let result = this.enumMembers[object[0].text][name].clone();
+                result.fileStack = this.getFileStackRange(object.concat(...member));
+                return result;
             }
 
             //Fix for older gamemodes

--- a/src/languageServer/server.ts
+++ b/src/languageServer/server.ts
@@ -323,7 +323,7 @@ function clearPendingValidation(uri: string): void {
 async function validateAndPublish(document: TextDocument): Promise<void> {
     try {
         const settings = await getDocumentSettings(document.uri);
-        const validationResult = await validateTextDocument(document, settings.workshopLanguage);
+        const validationResult = await validateTextDocument(document, settings.workshopLanguage, documents.all());
         publishDiagnostics(document.uri, validationResult.diagnosticsByUri);
         if (hasSemanticTokensRefreshSupport) {
             void connection.languages.semanticTokens.refresh();

--- a/src/languageServer/validation.ts
+++ b/src/languageServer/validation.ts
@@ -6,6 +6,7 @@ import { URI } from "vscode-uri";
 
 import { compile } from "../compiler/compiler";
 import type { OWLanguage } from "../types";
+import { setFileContentOverlay } from "../utils/file";
 import { OpyError } from "../utils/logging";
 import { groupDiagnosticsByUri, getDocumentFileInfo } from "./diagnostics";
 import { updateCompletionStateFromCompileResult } from "./completionState";
@@ -19,10 +20,12 @@ export type ValidationResult = {
 export async function validateTextDocument(
     document: TextDocument,
     workshopLanguage: OWLanguage = "en-US",
+    openDocuments: readonly TextDocument[] = [document],
 ): Promise<ValidationResult> {
     await initializeLanguageServerRuntime();
 
     const { rootPath, mainFileName } = getDocumentFileInfo(document);
+    setFileContentOverlay(buildFileContentOverlay(openDocuments));
 
     try {
         const compileResult = await compile(document.getText(), workshopLanguage, rootPath, mainFileName);
@@ -41,6 +44,17 @@ export async function validateTextDocument(
 
         throw error;
     }
+}
+
+function buildFileContentOverlay(openDocuments: readonly TextDocument[]): Map<string, string> {
+    const overlay = new Map<string, string>();
+    for (const openDocument of openDocuments) {
+        const fsPath = URI.parse(openDocument.uri).fsPath.replaceAll("\\", "/");
+        if (fsPath.endsWith(".opy")) {
+            overlay.set(fsPath, openDocument.getText());
+        }
+    }
+    return overlay;
 }
 
 /**

--- a/src/test/languageServer.test.ts
+++ b/src/test/languageServer.test.ts
@@ -758,6 +758,61 @@ async function main(): Promise<void> {
     const validDiagnostics = validValidation.diagnosticsByUri.get(validDocument.uri) ?? [];
     assert.equal(validDiagnostics.filter((item) => item.severity === DiagnosticSeverity.Error).length, 0);
 
+    // An error from a resolved enum member must point at the usage site, not the enum definition.
+    const enumUsageDocument = TextDocument.create(
+        "file:///tmp/enum-usage.opy",
+        "overpy",
+        1,
+        ["enum Wa:", "    h = 1", "", "Wa.h"].join("\n"),
+    );
+    const enumUsageValidation = await validateTextDocument(enumUsageDocument, "en-US");
+    const enumUsageDiagnostics = enumUsageValidation.diagnosticsByUri.get(enumUsageDocument.uri) ?? [];
+    const enumUsageError = enumUsageDiagnostics.find((item) => item.severity === DiagnosticSeverity.Error);
+    assert.ok(enumUsageError, "expected an error for an enum member used outside a rule");
+    assert.equal(enumUsageError.range.start.line, 3, "enum usage error should be on the `Wa.h` line");
+    assert.equal(enumUsageError.range.start.character, 0);
+
+    // An error from a resolved macro constant must point at the usage site, not the macro definition.
+    const macroUsageDocument = TextDocument.create(
+        "file:///tmp/macro-usage.opy",
+        "overpy",
+        1,
+        ["macro foo = 1", "", "foo"].join("\n"),
+    );
+    const macroUsageValidation = await validateTextDocument(macroUsageDocument, "en-US");
+    const macroUsageDiagnostics = macroUsageValidation.diagnosticsByUri.get(macroUsageDocument.uri) ?? [];
+    const macroUsageError = macroUsageDiagnostics.find((item) => item.severity === DiagnosticSeverity.Error);
+    assert.ok(macroUsageError, "expected an error for a macro constant used outside a rule");
+    assert.equal(macroUsageError.range.start.line, 2, "macro usage error should be on the `foo` line");
+    assert.equal(macroUsageError.range.start.character, 0);
+
+    // A placement error from an expanded function macro must point at the call site, not the macro body.
+    const macroCallDocument = TextDocument.create(
+        "file:///tmp/macro-call.opy",
+        "overpy",
+        1,
+        ["macro a(b, c):", "    b + c", "", "a(1, 2)"].join("\n"),
+    );
+    const macroCallValidation = await validateTextDocument(macroCallDocument, "en-US");
+    const macroCallDiagnostics = macroCallValidation.diagnosticsByUri.get(macroCallDocument.uri) ?? [];
+    const macroCallError = macroCallDiagnostics.find((item) => item.severity === DiagnosticSeverity.Error);
+    assert.ok(macroCallError, "expected an error for a function macro called outside a rule");
+    assert.equal(macroCallError.range.start.line, 3, "function macro placement error should be on the `a(1, 2)` line");
+    assert.equal(macroCallError.range.start.character, 0);
+
+    // A real error inside a macro body must still point into the body, not the call site.
+    const macroBodyErrorDocument = TextDocument.create(
+        "file:///tmp/macro-body.opy",
+        "overpy",
+        1,
+        ["macro a(b, c):", "    b + c + zzz", "", "rule \"r\":", "    @Event global", "    a(1, 2)"].join("\n"),
+    );
+    const macroBodyErrorValidation = await validateTextDocument(macroBodyErrorDocument, "en-US");
+    const macroBodyErrorDiagnostics = macroBodyErrorValidation.diagnosticsByUri.get(macroBodyErrorDocument.uri) ?? [];
+    const macroBodyError = macroBodyErrorDiagnostics.find((item) => item.severity === DiagnosticSeverity.Error);
+    assert.ok(macroBodyError, "expected an error for an undefined name in a macro body");
+    assert.equal(macroBodyError.range.start.line, 1, "macro body error should stay on the body line");
+
     const documentedDocument = TextDocument.create(
         "file:///tmp/documented.opy",
         "overpy",

--- a/src/test/languageServer.test.ts
+++ b/src/test/languageServer.test.ts
@@ -912,6 +912,42 @@ async function main(): Promise<void> {
     const bleedBuiltinHover = getHover(bleedDocA, { line: 5, character: "    scoreA = scaleA(sco".length });
     assert.ok(bleedBuiltinHover, "built-in/user symbols in A still hover after B validated");
 
+    const overlayRoot = await mkdtemp(path.join(tmpdir(), "overpy-overlay-"));
+    try {
+        const includePath = path.join(overlayRoot, "lib.opy");
+        await writeFile(includePath, "macro ON_DISK_MACRO = 1\n");
+        const overlayMainPath = path.join(overlayRoot, "overlay-main.opy");
+        const overlayMainText = [
+            "#!include \"lib.opy\"",
+            "globalvar score",
+            "rule \"r\":",
+            "    @Event global",
+            "    score = ON_DISK_MACRO",
+        ].join("\n");
+        await writeFile(overlayMainPath, overlayMainText);
+
+        const overlayMainDoc = TextDocument.create(URI.file(overlayMainPath).toString(), "overpy", 1, overlayMainText);
+        const overlayIncludeDoc = TextDocument.create(
+            URI.file(includePath).toString(),
+            "overpy",
+            2,
+            "macro ON_DISK_MACRO = 1\nmacro UNSAVED_MACRO = 2\n",
+        );
+
+        await validateTextDocument(overlayMainDoc, "en-US", [overlayMainDoc, overlayIncludeDoc]);
+        const overlayCompletions = getCompletionList(overlayMainDoc, { line: 2, character: 0 });
+        assert.ok(
+            overlayCompletions.items.some((item) => item.label === "ON_DISK_MACRO"),
+            "on-disk include macro must still resolve",
+        );
+        assert.ok(
+            overlayCompletions.items.some((item) => item.label === "UNSAVED_MACRO"),
+            "unsaved open-include macro must resolve from the live buffer overlay",
+        );
+    } finally {
+        await rm(overlayRoot, { force: true, recursive: true });
+    }
+
     // Closing a main file must clear diagnostics it published to its includes,
     // but never blank an include that is open or still published-to by another main file.
     const mainUri = "file:///tmp/close-main.opy";

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -20,6 +20,12 @@
 import {OverPyCompiler} from "../godClasses";
 import { debug } from "./logging";
 
+let fileContentOverlay = new Map<string, string>();
+
+export function setFileContentOverlay(overlay: Map<string, string>): void {
+    fileContentOverlay = overlay;
+}
+
 OverPyCompiler.prototype.getFilenameFromPath = function(filename: string) {
     try {
         var path = require("path");
@@ -69,14 +75,21 @@ OverPyCompiler.prototype.getFilePaths = function(pathStr: string, basePath: stri
 }
 
 OverPyCompiler.prototype.getFileContent = function(path: string): string {
+    if (path.endsWith(".opy") && this.importedFiles.includes(path)) {
+        this.warn("w_already_imported", "The file '" + path + "' was already imported and will not be imported again.");
+        return "";
+    }
+
+    const overlayContent = fileContentOverlay.get(path);
+    if (overlayContent !== undefined) {
+        this.importedFiles.push(path);
+        return overlayContent + "\n";
+    }
+
     try {
         var fs = require("fs");
     } catch (e) {
         this.error("Cannot import files in browsers (fs not found)");
-    }
-    if (path.endsWith(".opy") && this.importedFiles.includes(path)) {
-        this.warn("w_already_imported", "The file '" + path + "' was already imported and will not be imported again.");
-        return "";
     }
     try {
         this.importedFiles.push(path);


### PR DESCRIPTION
Fixed the regression where unsaved files were not showing autocomplete.

Additionally, I fixed an issue where error squiggles were showing up in macro/enum definitions instead of where the actual error was e.g.
```opy
enum Foo:
  bar = 1  # <--- error shown here incorrect
  
Foo.bar    # <--- error now shows here
```