### PR TITLE
Empty rule names crash regression

### DIFF
--- a/src/languageServer/symbols.ts
+++ b/src/languageServer/symbols.ts
@@ -76,16 +76,16 @@ function parseRule(line: string): Omit<StructuralItem, "line"> | null {
     }
 
     const quoteChar = match[3];
+    const ruleName = match[4] ?? "";
     const nameStart = line.indexOf(quoteChar) + 1;
-    const name = match[4] || "<empty>";
     return {
         detail: "rule",
         indent: getIndent(match[1] ?? ""),
         isBlock: true,
         kind: SymbolKind.Event,
-        name,
+        name: ruleName || "<empty>",
         nameStart,
-        nameEnd: nameStart + name.length,
+        nameEnd: nameStart + ruleName.length,
     };
 }
 

--- a/src/test/languageServer.test.ts
+++ b/src/test/languageServer.test.ts
@@ -306,6 +306,16 @@ async function main(): Promise<void> {
         end: { line: 12, character: 11 },
     });
 
+    const emptyRuleDocument = TextDocument.create("file:///tmp/empty-rule.opy", "overpy", 1, "rule \"\":");
+    const emptyRuleSymbol = getDocumentSymbols(emptyRuleDocument)[0];
+    assert.equal(emptyRuleSymbol?.name, "<empty>");
+    assert.ok(
+        emptyRuleSymbol.selectionRange.start.line >= emptyRuleSymbol.range.start.line &&
+            emptyRuleSymbol.selectionRange.end.line <= emptyRuleSymbol.range.end.line &&
+            emptyRuleSymbol.selectionRange.end.character <= emptyRuleSymbol.range.end.character,
+        "selectionRange must be contained in range for an empty rule name",
+    );
+
     const foldingRanges = getFoldingRanges(structureDocument);
     assert.ok(
         foldingRanges.some(


### PR DESCRIPTION
When a rule had an empty name, the symbol's selection range was sized using the `<empty>` placeholder label instead of the real text, which is 0 characters. That pushed the selection range past the end of the line.

Fixed by sizing the selection range from the actual rule text and only uses `<empty>` as the label.